### PR TITLE
Release v1.1.0 — Cloudflare deployment support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,93 @@
+name: Bug report
+description: Report a problem with CloakMail
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report! Please fill out the
+        sections below so we can reproduce and fix the issue quickly.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of what went wrong.
+      placeholder: When I send an email to my disposable address, it never appears in the inbox UI.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+      placeholder: The email should appear in the inbox within a few seconds.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to reproduce the behavior.
+      placeholder: |
+        1. Run `docker compose up -d`
+        2. Generate an inbox at https://example.com
+        3. Send an email to <generated-address>@example.com
+        4. Refresh the inbox — nothing appears
+    validations:
+      required: true
+
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: Deployment path
+      description: Which CloakMail deployment are you running?
+      options:
+        - Docker / VPS (`packages/server`)
+        - Cloudflare Workers (`packages/cloudflare` via `cloakmail-cli`)
+        - Local dev (`bun run dev` in a package)
+        - Other (describe below)
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: CloakMail version
+      description: Either the git tag, the GHCR image tag, or the cloakmail-cli output.
+      placeholder: v1.1.0
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: |
+        Anything relevant about your setup:
+        - OS + version
+        - Bun version (`bun --version`)
+        - Docker version (`docker --version`) if applicable
+        - Browser if it's a UI bug
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Server logs, browser console errors, or `wrangler tail` output. Paste relevant lines only.
+      render: shell
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://docs.cloakmail.dev
+    about: Setup guides, API reference, deployment instructions
+  - name: GitHub Discussions
+    url: https://github.com/DreamsHive/cloakmail/discussions
+    about: Ask questions, share ideas, or talk to other users
+  - name: Security vulnerabilities
+    url: mailto:rully@dreamshive.io
+    about: Please email security issues privately instead of opening a public issue

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,69 @@
+name: Feature request
+description: Suggest a new feature or improvement for CloakMail
+title: "[Feature]: "
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to suggest a feature! Please describe the
+        problem you're trying to solve before jumping to a specific solution —
+        it gives us more room to find the best approach together.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the use case or pain point that motivated this request.
+      placeholder: I want to share a disposable inbox link with my team without anyone else being able to read it.
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you like to see happen?
+      placeholder: Add an optional per-inbox passphrase that gates the inbox view.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you thought about and why you didn't pick them.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Which package(s) would this touch?
+      multiple: true
+      options:
+        - packages/server (Docker path)
+        - packages/web (SvelteKit UI)
+        - packages/cloudflare (Workers path)
+        - cloakmail-cli (deployment wizard)
+        - Documentation
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Screenshots, mockups, links to similar features in other projects, etc.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,46 @@
+## Summary
+
+<!-- One or two sentences describing what this PR does and why. -->
+
+## Type of change
+
+<!-- Mark the relevant box with an x. -->
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Refactor / cleanup (no functional change)
+- [ ] CI / tooling
+
+## Affected packages
+
+<!-- Mark every package this PR touches. -->
+
+- [ ] `packages/server` (Docker / VPS deployment)
+- [ ] `packages/web` (SvelteKit UI)
+- [ ] `packages/cloudflare` (Workers + D1 + R2)
+- [ ] CI / GitHub workflows
+- [ ] Documentation
+
+## Test plan
+
+<!-- How did you verify this works? Include commands run, screenshots, or
+     links to deployments. Both deployment paths (Docker and Cloudflare)
+     should remain working — call out which one(s) you tested. -->
+
+- [ ] `bun test` passes in every touched package
+- [ ] `bun run build` in `packages/web` still produces a working Node build
+- [ ] `ADAPTER=cloudflare bun run build` in `packages/web` still produces a working Cloudflare build (if you touched the web package)
+- [ ] Manual smoke test against a real deployment (describe below)
+
+## Related issues
+
+<!-- e.g. Closes #123, Related to #456 -->
+
+## Checklist
+
+- [ ] My code follows the existing style of the project
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] I have updated documentation as needed
+- [ ] My commits follow the [conventional commits](https://www.conventionalcommits.org/) format

--- a/.github/workflows/cloudflare-deploy.yml
+++ b/.github/workflows/cloudflare-deploy.yml
@@ -1,0 +1,90 @@
+name: Cloudflare Deploy
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/cloudflare/**'
+      - 'packages/web/**'
+      - '.github/workflows/cloudflare-deploy.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'packages/cloudflare/**'
+      - 'packages/web/**'
+      - '.github/workflows/cloudflare-deploy.yml'
+  workflow_dispatch:
+
+jobs:
+  test-cloudflare:
+    name: Test Cloudflare Worker
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: cd packages/cloudflare && bun install
+
+      - name: Run vitest
+        run: cd packages/cloudflare && bun run test
+
+  deploy-api:
+    name: Deploy API Worker
+    needs: test-cloudflare
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: cd packages/cloudflare && bun install
+
+      - name: Apply D1 migrations
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: packages/cloudflare
+          command: d1 migrations apply DB --remote
+
+      - name: Deploy API Worker
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: packages/cloudflare
+          command: deploy
+
+  deploy-web:
+    name: Deploy Web Worker
+    needs: deploy-api
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: cd packages/web && bun install
+
+      - name: Build SvelteKit (cloudflare adapter)
+        run: cd packages/web && bun run build:cloudflare
+
+      - name: Deploy Web Worker
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: packages/web
+          command: deploy

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,163 @@
+name: Publish
+
+# Triggered by pushing a `v*` tag (e.g. `v1.1.0`) or manually via the
+# Actions UI. Re-runs the full test suite as a safety net, then publishes
+# every workspace package whose `package.json` is NOT marked `"private": true`.
+# Currently all packages are private — flip the flag on the ones you want
+# released and the next tag will pick them up automatically.
+#
+# Modeled after the seedcli publish workflow:
+# https://github.com/DreamsHive/seedcli/blob/main/.github/workflows/publish.yml
+
+on:
+  push:
+    tags:
+      - "v[0-9]*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to publish (e.g. v1.1.0)"
+        required: true
+
+concurrency:
+  group: publish
+  cancel-in-progress: false
+
+jobs:
+  ci:
+    name: CI
+    runs-on: ubuntu-latest
+
+    # The server package's tests need a real Redis instance, same as the
+    # main `ci.yml` workflow. We re-run them here so a tag pointing at an
+    # untested commit can never accidentally ship.
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Server tests
+        working-directory: packages/server
+        run: |
+          bun install
+          bun test
+        env:
+          REDIS_URL: redis://localhost:6379
+
+      - name: Web tests + build
+        working-directory: packages/web
+        run: |
+          bun install
+          bun run test
+          bun run build
+
+      - name: Cloudflare tests
+        working-directory: packages/cloudflare
+        run: |
+          bun install
+          bun run test
+
+  publish:
+    name: Publish to npm
+    needs: ci
+    runs-on: ubuntu-latest
+
+    # `id-token: write` is required for npm provenance attestation.
+    # `contents: write` is required for the GitHub Release step at the bottom.
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      # We use `bun install` for speed but `npm publish` for the actual
+      # release because npm CLI is the only client that supports the
+      # `--provenance` flag against the public registry today.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install workspace dependencies
+        run: bun install
+
+      - name: Publish non-private packages
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          published=0
+          skipped=0
+          failed=0
+
+          for pkg_dir in packages/*/; do
+            pkg_json="${pkg_dir}package.json"
+            [ -f "$pkg_json" ] || continue
+
+            name=$(node -p "require('./${pkg_json}').name")
+            version=$(node -p "require('./${pkg_json}').version")
+            is_private=$(node -p "require('./${pkg_json}').private === true")
+
+            if [ "$is_private" = "true" ]; then
+              echo "  → $name@$version (private, skipped)"
+              skipped=$((skipped + 1))
+              continue
+            fi
+
+            # Idempotency: skip if this exact version is already on npm.
+            # Without this, retriggering the workflow would 403 on the
+            # second run because npm refuses to overwrite existing versions.
+            if npm view "$name@$version" version >/dev/null 2>&1; then
+              echo "  → $name@$version (already published, skipped)"
+              skipped=$((skipped + 1))
+              continue
+            fi
+
+            echo "  → Publishing $name@$version..."
+            if (cd "$pkg_dir" && npm publish --access public --provenance); then
+              published=$((published + 1))
+            else
+              echo "    FAILED"
+              failed=$((failed + 1))
+            fi
+          done
+
+          echo ""
+          echo "Published: $published"
+          echo "Skipped:   $skipped"
+          echo "Failed:    $failed"
+
+          if [ "$failed" -gt 0 ]; then
+            exit 1
+          fi
+
+      # Auto-generated release notes from merged PRs since the previous tag.
+      # Skipped on manual workflow_dispatch runs because there's no implicit
+      # tag context to anchor the notes against.
+      - name: Create GitHub Release
+        if: ${{ !inputs.tag }}
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ Thumbs.db
 
 # Logs
 *.log
+CLOUDFLARE_PLAN.md

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,40 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainers at **rully@dreamshive.io**.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/),
+version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,138 @@
+# Contributing to CloakMail
+
+Thanks for your interest in contributing to CloakMail! This guide will help you get started.
+
+## Prerequisites
+
+- [Bun](https://bun.sh/) v1.3 or later
+- [Docker](https://docs.docker.com/get-docker/) (for the `server` package's local Redis)
+- [Git](https://git-scm.com/)
+
+## Setup
+
+1. Fork and clone the repository:
+
+   ```bash
+   git clone git@github.com:YOUR_USERNAME/cloakmail.git
+   cd cloakmail
+   ```
+
+2. Install dependencies for each package you plan to work on:
+
+   ```bash
+   cd packages/server   && bun install
+   cd ../web            && bun install
+   cd ../cloudflare     && bun install
+   ```
+
+3. Verify everything works:
+
+   ```bash
+   # In packages/server (needs Redis on :6379)
+   bun test
+
+   # In packages/web
+   bun run test
+   bun run build
+
+   # In packages/cloudflare
+   bun run test
+   ```
+
+## Project Structure
+
+```
+cloakmail/
+├── packages/
+│   ├── server/         # Bun + Elysia API + smtp-server (Docker / VPS deployment)
+│   ├── web/            # SvelteKit UI (works with both adapter-node and adapter-cloudflare)
+│   └── cloudflare/     # Cloudflare Workers + D1 + R2 + Email Routing (serverless deployment)
+├── docker-compose.yml             # local dev (Redis + server + web)
+├── docker-compose.production.yml  # production Docker stack
+└── .github/workflows/             # CI, Docker publish, npm publish, Cloudflare deploy
+```
+
+The two deployment paths (Docker via `packages/server` and Cloudflare via `packages/cloudflare`) share the SvelteKit UI in `packages/web` and a small amount of duplicated code (`spam.ts`, `types.ts`) — but each has its own storage backend (Redis vs D1+R2).
+
+## Development Workflow
+
+### Server (Docker path)
+
+```bash
+cd packages/server
+bun run dev          # auto-reload on src/ changes
+bun test             # unit + integration tests (requires Redis)
+```
+
+### Web
+
+```bash
+cd packages/web
+bun run dev                  # SvelteKit dev server (adapter-node by default)
+ADAPTER=cloudflare bun run build   # build for Cloudflare Workers
+bun run test                 # vitest
+```
+
+### Cloudflare
+
+```bash
+cd packages/cloudflare
+bun run dev                  # wrangler dev with miniflare D1+R2
+bun run test                 # vitest via @cloudflare/vitest-pool-workers
+```
+
+For end-to-end Cloudflare deployment from a fork, use the [`cloakmail-cli`](https://github.com/DreamsHive/cloakmail-cli) wizard with `--from /path/to/your/fork` so it skips the GitHub tarball fetch and uses your local checkout.
+
+## Making Changes
+
+1. Create a branch from `main`:
+
+   ```bash
+   git checkout -b feat/my-feature
+   ```
+
+2. Make your changes and ensure:
+   - Tests pass in any package you touched
+   - The Docker `bun run build` in `packages/web` still produces a working `build/` directory (regression check for the Node adapter path)
+   - The Cloudflare adapter still builds: `cd packages/web && ADAPTER=cloudflare bun run build`
+
+3. Write tests for new features or bug fixes.
+
+4. Submit a pull request against `main`. Reference any related issues in the description.
+
+## Commit Messages
+
+We follow [conventional commits](https://www.conventionalcommits.org/):
+
+```
+feat(cloudflare): add R2 spillover for emails > 100KB
+fix(server): handle malformed MIME headers without crashing
+refactor(web): consolidate same-origin fetch logic
+docs: document the cloakmail-cli wizard flow
+test(cloudflare): cover the smart-split threshold
+chore: bump dependencies
+```
+
+The scope (in parentheses) is optional but encouraged when a change is package-specific.
+
+## Pull Requests
+
+- Keep PRs focused — one feature or fix per PR
+- Include tests for new functionality
+- Update documentation if user-visible behavior changes
+- Make sure CI passes before requesting review
+- Both deployment paths (Docker and Cloudflare) should remain working — don't accidentally break one to fix the other
+
+## Reporting Bugs
+
+Open an issue using the bug report template with:
+
+- Clear description of the problem
+- Minimal reproduction steps
+- Expected vs actual behavior
+- Deployment path: Docker (which compose file?) or Cloudflare (Workers + D1 + R2)
+- Bun version (`bun --version`) and OS
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -36,8 +36,18 @@
 - **REST API** — fully documented OpenAPI spec with typed endpoints
 - **Web UI** — Accessible web interface built with SvelteKit and Tailwind CSS
 - **Docker-ready** — single `docker compose up` to run the entire stack
+- **Serverless on Cloudflare** — deploy to Workers + D1 + R2 + Email Routing on the free tier with a single command, no servers to manage
 
 ## Quick Start
+
+CloakMail ships with two deployment paths. Pick the one that fits your situation:
+
+| Deployment | Good for | Cost |
+|---|---|---|
+| **Docker / VPS** | Full control, self-hosted servers, on-prem | Your server costs |
+| **Cloudflare Workers** | Zero servers to manage, global edge, free tier | $0 on the free tier (up to ~100k emails/day) |
+
+### Option 1 — Docker / VPS
 
 Pull and run directly from GitHub Container Registry:
 
@@ -61,7 +71,7 @@ docker pull ghcr.io/dreamshive/cloakmail-web:latest
 
 The web UI will be available at `http://localhost:5173` and the API at `http://localhost:3000`.
 
-### Environment Variables
+#### Environment Variables
 
 | Variable | Default | Description |
 |---|---|---|
@@ -70,8 +80,34 @@ The web UI will be available at `http://localhost:5173` and the API at `http://l
 | `EMAIL_TTL_SECONDS` | `86400` | Time before emails auto-delete |
 | `SMTP_PORT` | `25` | SMTP server port |
 | `API_PORT` | `3000` | REST API port |
+| `API_URL` | `http://server:3000` | Overrides `PUBLIC_API_URL` for the web container — useful for split deployments or reverse-proxy setups |
 
 See [.env.example](.env.example) for all available options.
+
+### Option 2 — Cloudflare Workers
+
+Run CloakMail entirely on Cloudflare's free tier — no servers, no Docker, no `ssh`. One command from any directory on your machine:
+
+```bash
+bunx cloakmail-cli setup
+```
+
+The [`cloakmail-cli`](https://github.com/DreamsHive/cloakmail-cli) wizard handles the entire deployment end-to-end: it fetches this repo's release tarball, prompts for your Cloudflare API token + domain + hostname, provisions D1 and R2, deploys both Workers, configures Email Routing, binds your custom domain, and verifies the whole thing — in about two minutes.
+
+**Prerequisites:**
+
+- A Cloudflare account (free tier is fine)
+- A domain already added to Cloudflare DNS
+- [Bun](https://bun.sh/) installed locally (for `bunx`)
+
+**What you get:**
+
+- A web UI at whatever hostname you pick (e.g. `https://inbox.yourdomain.com`)
+- Catch-all email routing on your domain — any address `*@yourdomain.com` lands in a disposable inbox
+- Automatic TLS via Cloudflare
+- ~100k emails/day on the free tier (D1 + R2 smart-split storage)
+
+The Docker and Cloudflare paths are fully independent — pick whichever fits your setup, or even run both for different domains.
 
 ## Documentation
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,8 +1,24 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "ghostmail",
+    },
+    "packages/cloudflare": {
+      "name": "@cloakmail/cloudflare",
+      "version": "1.0.0",
+      "dependencies": {
+        "hono": "^4.6.14",
+        "postal-mime": "^2.4.3",
+      },
+      "devDependencies": {
+        "@cloudflare/vitest-pool-workers": "^0.6.0",
+        "@cloudflare/workers-types": "^4.20250109.0",
+        "typescript": "^5.7.0",
+        "vitest": "~2.1.9",
+        "wrangler": "^3.99.0",
+      },
     },
     "packages/server": {
       "name": "@cloakmail/server",
@@ -28,6 +44,7 @@
         "openapi-fetch": "^0.15.0",
       },
       "devDependencies": {
+        "@sveltejs/adapter-cloudflare": "^7.2.8",
         "@sveltejs/adapter-node": "^5.5.0",
         "@sveltejs/kit": "^2.50.1",
         "@sveltejs/vite-plugin-svelte": "^6.2.4",
@@ -49,67 +66,135 @@
 
     "@borewit/text-codec": ["@borewit/text-codec@0.2.1", "", {}, "sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw=="],
 
+    "@cloakmail/cloudflare": ["@cloakmail/cloudflare@workspace:packages/cloudflare"],
+
     "@cloakmail/server": ["@cloakmail/server@workspace:packages/server"],
 
     "@cloakmail/web": ["@cloakmail/web@workspace:packages/web"],
 
+    "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.3.4", "", { "dependencies": { "mime": "^3.0.0" } }, "sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q=="],
+
+    "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.0.2", "", { "peerDependencies": { "unenv": "2.0.0-rc.14", "workerd": "^1.20250124.0" }, "optionalPeers": ["workerd"] }, "sha512-nyzYnlZjjV5xT3LizahG1Iu6mnrCaxglJ04rZLpDwlDVDZ7v46lNsfxhV3A/xtfgQuSHmLnc6SVI+KwBpc3Lwg=="],
+
+    "@cloudflare/vitest-pool-workers": ["@cloudflare/vitest-pool-workers@0.6.16", "", { "dependencies": { "birpc": "0.2.14", "cjs-module-lexer": "^1.2.3", "devalue": "^4.3.0", "esbuild": "0.17.19", "miniflare": "3.20250204.1", "semver": "^7.5.1", "wrangler": "3.109.1", "zod": "^3.22.3" }, "peerDependencies": { "@vitest/runner": "2.0.x - 2.1.x", "@vitest/snapshot": "2.0.x - 2.1.x", "vitest": "2.0.x - 2.1.x" } }, "sha512-fKGP+jMyrIh54QncFa7A5NE3k8fWW6oCU4v9IW6Hiu7cAVKBvhdPUAfYBQS7EU1TsjGJl/y5N4Urds3PUFocoQ=="],
+
+    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20250718.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-FHf4t7zbVN8yyXgQ/r/GqLPaYZSGUVzeR7RnL28Mwj2djyw2ZergvytVc7fdGcczl6PQh+VKGfZCfUqpJlbi9g=="],
+
+    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20250718.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-fUiyUJYyqqp4NqJ0YgGtp4WJh/II/YZsUnEb6vVy5Oeas8lUOxnN+ZOJ8N/6/5LQCVAtYCChRiIrBbfhTn5Z8Q=="],
+
+    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20250718.0", "", { "os": "linux", "cpu": "x64" }, "sha512-5+eb3rtJMiEwp08Kryqzzu8d1rUcK+gdE442auo5eniMpT170Dz0QxBrqkg2Z48SFUPYbj+6uknuA5tzdRSUSg=="],
+
+    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20250718.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Aa2M/DVBEBQDdATMbn217zCSFKE+ud/teS+fFS+OQqKABLn0azO2qq6ANAHYOIE6Q3Sq4CxDIQr8lGdaJHwUog=="],
+
+    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20250718.0", "", { "os": "win32", "cpu": "x64" }, "sha512-dY16RXKffmugnc67LTbyjdDHZn5NoTF1yHEf2fN4+OaOnoGSp3N1x77QubTDwqZ9zECWxgQfDLjddcH8dWeFhg=="],
+
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260405.1", "", {}, "sha512-PokTmySa+D6MY01R1UfYH48korsN462NK/fl3aw47Hg7XuLuSo/RTpjT0vtWaJhJoFY5tHGOBBIbDcIc8wltLg=="],
+
+    "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
+
     "@elysiajs/swagger": ["@elysiajs/swagger@1.3.1", "", { "dependencies": { "@scalar/themes": "^0.9.52", "@scalar/types": "^0.0.12", "openapi-types": "^12.1.3", "pathe": "^1.1.2" }, "peerDependencies": { "elysia": ">= 1.3.0" } }, "sha512-LcbLHa0zE6FJKWPWKsIC/f+62wbDv3aXydqcNPVPyqNcaUgwvCajIi+5kHEU6GO3oXUCpzKaMsb3gsjt8sLzFQ=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
+
+    "@esbuild-plugins/node-globals-polyfill": ["@esbuild-plugins/node-globals-polyfill@0.2.3", "", { "peerDependencies": { "esbuild": "*" } }, "sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw=="],
+
+    "@esbuild-plugins/node-modules-polyfill": ["@esbuild-plugins/node-modules-polyfill@0.2.2", "", { "dependencies": { "escape-string-regexp": "^4.0.0", "rollup-plugin-node-polyfills": "^0.2.1" }, "peerDependencies": { "esbuild": "*" } }, "sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw=="],
 
-    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.2", "", { "os": "android", "cpu": "arm" }, "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA=="],
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.17.19", "", { "os": "android", "cpu": "arm" }, "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A=="],
 
-    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.2", "", { "os": "android", "cpu": "arm64" }, "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA=="],
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.17.19", "", { "os": "android", "cpu": "arm64" }, "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA=="],
 
-    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.2", "", { "os": "android", "cpu": "x64" }, "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A=="],
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.17.19", "", { "os": "android", "cpu": "x64" }, "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww=="],
 
-    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg=="],
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.17.19", "", { "os": "darwin", "cpu": "arm64" }, "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg=="],
 
-    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA=="],
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.17.19", "", { "os": "darwin", "cpu": "x64" }, "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw=="],
 
-    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g=="],
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.17.19", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ=="],
 
-    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA=="],
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.17.19", "", { "os": "freebsd", "cpu": "x64" }, "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ=="],
 
-    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.2", "", { "os": "linux", "cpu": "arm" }, "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw=="],
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.17.19", "", { "os": "linux", "cpu": "arm" }, "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA=="],
 
-    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw=="],
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.17.19", "", { "os": "linux", "cpu": "arm64" }, "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg=="],
 
-    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.2", "", { "os": "linux", "cpu": "ia32" }, "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w=="],
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.17.19", "", { "os": "linux", "cpu": "ia32" }, "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ=="],
 
-    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.2", "", { "os": "linux", "cpu": "none" }, "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg=="],
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.17.19", "", { "os": "linux", "cpu": "none" }, "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ=="],
 
-    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.2", "", { "os": "linux", "cpu": "none" }, "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw=="],
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.17.19", "", { "os": "linux", "cpu": "none" }, "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A=="],
 
-    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ=="],
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.17.19", "", { "os": "linux", "cpu": "ppc64" }, "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg=="],
 
-    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.2", "", { "os": "linux", "cpu": "none" }, "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA=="],
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.17.19", "", { "os": "linux", "cpu": "none" }, "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA=="],
 
-    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w=="],
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.17.19", "", { "os": "linux", "cpu": "s390x" }, "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q=="],
 
-    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.2", "", { "os": "linux", "cpu": "x64" }, "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA=="],
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.17.19", "", { "os": "linux", "cpu": "x64" }, "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw=="],
 
     "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.2", "", { "os": "none", "cpu": "arm64" }, "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw=="],
 
-    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.2", "", { "os": "none", "cpu": "x64" }, "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA=="],
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.17.19", "", { "os": "none", "cpu": "x64" }, "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q=="],
 
     "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA=="],
 
-    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg=="],
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.17.19", "", { "os": "openbsd", "cpu": "x64" }, "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g=="],
 
     "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.2", "", { "os": "none", "cpu": "arm64" }, "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag=="],
 
-    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg=="],
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.17.19", "", { "os": "sunos", "cpu": "x64" }, "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg=="],
 
-    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg=="],
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.17.19", "", { "os": "win32", "cpu": "arm64" }, "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag=="],
 
-    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ=="],
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.17.19", "", { "os": "win32", "cpu": "ia32" }, "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw=="],
 
-    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.2", "", { "os": "win32", "cpu": "x64" }, "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ=="],
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.17.19", "", { "os": "win32", "cpu": "x64" }, "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA=="],
+
+    "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
 
     "@iconify/svelte": ["@iconify/svelte@5.2.1", "", { "dependencies": { "@iconify/types": "^2.0.0" }, "peerDependencies": { "svelte": ">5.0.0" } }, "sha512-zHmsIPmnIhGd5gc95bNN5FL+GifwMZv7M2rlZEpa7IXYGFJm/XGHdWf6PWQa6OBoC+R69WyiPO9NAj5wjfjbow=="],
 
     "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.0.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.0.4" }, "os": "darwin", "cpu": "x64" }, "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.0.5", "", { "os": "linux", "cpu": "arm" }, "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA=="],
+
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.0.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.0.5" }, "os": "linux", "cpu": "arm" }, "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.0.4" }, "os": "linux", "cpu": "arm64" }, "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA=="],
+
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.0.4" }, "os": "linux", "cpu": "s390x" }, "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.0.4" }, "os": "linux", "cpu": "x64" }, "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.0.4" }, "os": "linux", "cpu": "arm64" }, "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.0.4" }, "os": "linux", "cpu": "x64" }, "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw=="],
+
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.33.5", "", { "dependencies": { "@emnapi/runtime": "^1.2.0" }, "cpu": "none" }, "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.33.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.33.5", "", { "os": "win32", "cpu": "x64" }, "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -201,6 +286,8 @@
 
     "@sveltejs/acorn-typescript": ["@sveltejs/acorn-typescript@1.0.8", "", { "peerDependencies": { "acorn": "^8.9.0" } }, "sha512-esgN+54+q0NjB0Y/4BomT9samII7jGwNy/2a3wNZbT2A2RpmXsXwUt24LvLhx6jUq2gVk4cWEvcRO6MFQbOfNA=="],
 
+    "@sveltejs/adapter-cloudflare": ["@sveltejs/adapter-cloudflare@7.2.8", "", { "dependencies": { "@cloudflare/workers-types": "^4.20250507.0", "worktop": "0.8.0-next.18" }, "peerDependencies": { "@sveltejs/kit": "^2.0.0", "wrangler": "^4.0.0" } }, "sha512-bIdhY/Fi4AQmqiBdQVKnafH1h9Gw+xbCvHyUu4EouC8rJOU02zwhi14k/FDhQ0mJF1iblIu3m8UNQ8GpGIvIOQ=="],
+
     "@sveltejs/adapter-node": ["@sveltejs/adapter-node@5.5.2", "", { "dependencies": { "@rollup/plugin-commonjs": "^28.0.1", "@rollup/plugin-json": "^6.1.0", "@rollup/plugin-node-resolve": "^16.0.0", "rollup": "^4.9.5" }, "peerDependencies": { "@sveltejs/kit": "^2.4.0" } }, "sha512-L15Djwpr7HrSAPj/Z8PYfc0pa9A1tllrr18phKI0WJHJeoWw45yinPf0IGgVTmakqx1B3JQ+C/OFl9ZwmxHU1Q=="],
 
     "@sveltejs/kit": ["@sveltejs/kit@2.50.1", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@sveltejs/acorn-typescript": "^1.0.5", "@types/cookie": "^0.6.0", "acorn": "^8.14.1", "cookie": "^0.6.0", "devalue": "^5.6.2", "esm-env": "^1.2.2", "kleur": "^4.1.5", "magic-string": "^0.30.5", "mrmime": "^2.0.0", "sade": "^1.8.1", "set-cookie-parser": "^2.6.0", "sirv": "^3.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.0.0", "@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0", "svelte": "^4.0.0 || ^5.0.0-next.0", "typescript": "^5.3.3", "vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0" }, "optionalPeers": ["@opentelemetry/api", "typescript"], "bin": { "svelte-kit": "svelte-kit.js" } }, "sha512-XRHD2i3zC4ukhz2iCQzO4mbsts081PAZnnMAQ7LNpWeYgeBmwMsalf0FGSwhFXBbtr2XViPKnFJBDCckWqrsLw=="],
@@ -263,23 +350,25 @@
 
     "@unhead/schema": ["@unhead/schema@1.11.20", "", { "dependencies": { "hookable": "^5.5.3", "zhead": "^2.2.4" } }, "sha512-0zWykKAaJdm+/Y7yi/Yds20PrUK7XabLe9c3IRcjnwYmSWY6z0Cr19VIs3ozCj8P+GhR+/TI2mwtGlueCEYouA=="],
 
-    "@vitest/expect": ["@vitest/expect@4.0.18", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "chai": "^6.2.1", "tinyrainbow": "^3.0.3" } }, "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ=="],
+    "@vitest/expect": ["@vitest/expect@2.1.9", "", { "dependencies": { "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "tinyrainbow": "^1.2.0" } }, "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw=="],
 
-    "@vitest/mocker": ["@vitest/mocker@4.0.18", "", { "dependencies": { "@vitest/spy": "4.0.18", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ=="],
+    "@vitest/mocker": ["@vitest/mocker@2.1.9", "", { "dependencies": { "@vitest/spy": "2.1.9", "estree-walker": "^3.0.3", "magic-string": "^0.30.12" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg=="],
 
-    "@vitest/pretty-format": ["@vitest/pretty-format@4.0.18", "", { "dependencies": { "tinyrainbow": "^3.0.3" } }, "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw=="],
+    "@vitest/pretty-format": ["@vitest/pretty-format@2.1.9", "", { "dependencies": { "tinyrainbow": "^1.2.0" } }, "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ=="],
 
-    "@vitest/runner": ["@vitest/runner@4.0.18", "", { "dependencies": { "@vitest/utils": "4.0.18", "pathe": "^2.0.3" } }, "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw=="],
+    "@vitest/runner": ["@vitest/runner@2.1.9", "", { "dependencies": { "@vitest/utils": "2.1.9", "pathe": "^1.1.2" } }, "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g=="],
 
-    "@vitest/snapshot": ["@vitest/snapshot@4.0.18", "", { "dependencies": { "@vitest/pretty-format": "4.0.18", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA=="],
+    "@vitest/snapshot": ["@vitest/snapshot@2.1.9", "", { "dependencies": { "@vitest/pretty-format": "2.1.9", "magic-string": "^0.30.12", "pathe": "^1.1.2" } }, "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ=="],
 
-    "@vitest/spy": ["@vitest/spy@4.0.18", "", {}, "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw=="],
+    "@vitest/spy": ["@vitest/spy@2.1.9", "", { "dependencies": { "tinyspy": "^3.0.2" } }, "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ=="],
 
-    "@vitest/utils": ["@vitest/utils@4.0.18", "", { "dependencies": { "@vitest/pretty-format": "4.0.18", "tinyrainbow": "^3.0.3" } }, "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA=="],
+    "@vitest/utils": ["@vitest/utils@2.1.9", "", { "dependencies": { "@vitest/pretty-format": "2.1.9", "loupe": "^3.1.2", "tinyrainbow": "^1.2.0" } }, "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ=="],
 
     "@zone-eu/mailsplit": ["@zone-eu/mailsplit@5.4.8", "", { "dependencies": { "libbase64": "1.3.0", "libmime": "5.3.7", "libqp": "2.1.1" } }, "sha512-eEyACj4JZ7sjzRvy26QhLgKEMWwQbsw1+QZnlLX+/gihcNH07lVPOcnwf5U6UAL7gkc//J3jVd76o/WS+taUiA=="],
 
     "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
+
+    "acorn-walk": ["acorn-walk@8.3.2", "", {}, "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A=="],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
@@ -289,6 +378,8 @@
 
     "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
 
+    "as-table": ["as-table@1.0.55", "", { "dependencies": { "printable-characters": "^1.0.42" } }, "sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ=="],
+
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
@@ -297,31 +388,57 @@
 
     "base32.js": ["base32.js@0.1.0", "", {}, "sha512-n3TkB02ixgBOhTvANakDb4xaMXnYUVkNoRFJjQflcqMQhyEKxEHdj3E6N8t8sUQ0mjH/3/JxzlXuz3ul/J90pQ=="],
 
+    "birpc": ["birpc@0.2.14", "", {}, "sha512-37FHE8rqsYM5JEKCnXFyHpBCzvgHEExwVVTq+nUmloInU7l8ezD1TpOhKpS8oe1DTYFqEK27rFZVKG43oTqXRA=="],
+
+    "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
+
     "brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "bun-types": ["bun-types@1.3.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-qyschsA03Qz+gou+apt6HNl6HnI+sJJLL4wLDke4iugsE6584CMupOtTY1n+2YC9nGVrEKUlTs99jjRLKgWnjQ=="],
 
-    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+    "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
+    "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
 
     "change-case": ["change-case@5.4.4", "", {}, "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w=="],
 
+    "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
+
     "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
+    "cjs-module-lexer": ["cjs-module-lexer@1.4.3", "", {}, "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q=="],
+
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
+    "color": ["color@4.2.3", "", { "dependencies": { "color-convert": "^2.0.1", "color-string": "^1.9.0" } }, "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "color-string": ["color-string@1.9.1", "", { "dependencies": { "color-name": "^1.0.0", "simple-swizzle": "^0.2.2" } }, "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg=="],
 
     "colorette": ["colorette@1.4.0", "", {}, "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g=="],
 
     "commondir": ["commondir@1.0.1", "", {}, "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg=="],
 
+    "confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
+
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
+    "data-uri-to-buffer": ["data-uri-to-buffer@2.0.2", "", {}, "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
+
+    "defu": ["defu@6.1.6", "", {}, "sha512-f8mefEW4WIVg4LckePx3mALjQSPQgFlg9U8yaPdlsbdYcHQyj9n2zL2LJEA52smeYxOvmd/nB7TpMtHGMTHcug=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
-    "devalue": ["devalue@5.6.2", "", {}, "sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg=="],
+    "devalue": ["devalue@4.3.3", "", {}, "sha512-UH8EL6H2ifcY8TbD2QsxwCC/pr5xSwPvv85LrLXVihmHVC3T3YqTCIwnR5ak0yO1KYqlxrPVOA/JVZJYPy2ATg=="],
 
     "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
 
@@ -341,17 +458,23 @@
 
     "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
 
-    "esbuild": ["esbuild@0.27.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.2", "@esbuild/android-arm": "0.27.2", "@esbuild/android-arm64": "0.27.2", "@esbuild/android-x64": "0.27.2", "@esbuild/darwin-arm64": "0.27.2", "@esbuild/darwin-x64": "0.27.2", "@esbuild/freebsd-arm64": "0.27.2", "@esbuild/freebsd-x64": "0.27.2", "@esbuild/linux-arm": "0.27.2", "@esbuild/linux-arm64": "0.27.2", "@esbuild/linux-ia32": "0.27.2", "@esbuild/linux-loong64": "0.27.2", "@esbuild/linux-mips64el": "0.27.2", "@esbuild/linux-ppc64": "0.27.2", "@esbuild/linux-riscv64": "0.27.2", "@esbuild/linux-s390x": "0.27.2", "@esbuild/linux-x64": "0.27.2", "@esbuild/netbsd-arm64": "0.27.2", "@esbuild/netbsd-x64": "0.27.2", "@esbuild/openbsd-arm64": "0.27.2", "@esbuild/openbsd-x64": "0.27.2", "@esbuild/openharmony-arm64": "0.27.2", "@esbuild/sunos-x64": "0.27.2", "@esbuild/win32-arm64": "0.27.2", "@esbuild/win32-ia32": "0.27.2", "@esbuild/win32-x64": "0.27.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw=="],
+    "esbuild": ["esbuild@0.17.19", "", { "optionalDependencies": { "@esbuild/android-arm": "0.17.19", "@esbuild/android-arm64": "0.17.19", "@esbuild/android-x64": "0.17.19", "@esbuild/darwin-arm64": "0.17.19", "@esbuild/darwin-x64": "0.17.19", "@esbuild/freebsd-arm64": "0.17.19", "@esbuild/freebsd-x64": "0.17.19", "@esbuild/linux-arm": "0.17.19", "@esbuild/linux-arm64": "0.17.19", "@esbuild/linux-ia32": "0.17.19", "@esbuild/linux-loong64": "0.17.19", "@esbuild/linux-mips64el": "0.17.19", "@esbuild/linux-ppc64": "0.17.19", "@esbuild/linux-riscv64": "0.17.19", "@esbuild/linux-s390x": "0.17.19", "@esbuild/linux-x64": "0.17.19", "@esbuild/netbsd-x64": "0.17.19", "@esbuild/openbsd-x64": "0.17.19", "@esbuild/sunos-x64": "0.17.19", "@esbuild/win32-arm64": "0.17.19", "@esbuild/win32-ia32": "0.17.19", "@esbuild/win32-x64": "0.17.19" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw=="],
+
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
     "esm-env": ["esm-env@1.2.2", "", {}, "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA=="],
 
     "esrap": ["esrap@2.2.2", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15" } }, "sha512-zA6497ha+qKvoWIK+WM9NAh5ni17sKZKhbS5B3PoYbBvaYHZWoS33zmFybmyqpn07RLUxSmn+RCls2/XF+d0oQ=="],
 
-    "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "exact-mirror": ["exact-mirror@0.2.6", "", { "peerDependencies": { "@sinclair/typebox": "^0.34.15" }, "optionalPeers": ["@sinclair/typebox"] }, "sha512-7s059UIx9/tnOKSySzUk5cPGkoILhTE4p6ncf6uIPaQ+9aRBQzQjc9+q85l51+oZ+P6aBxh084pD0CzBQPcFUA=="],
 
+    "exit-hook": ["exit-hook@2.2.1", "", {}, "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw=="],
+
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
+    "exsolve": ["exsolve@1.0.8", "", {}, "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="],
 
     "fast-decode-uri-component": ["fast-decode-uri-component@1.0.1", "", {}, "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="],
 
@@ -367,11 +490,17 @@
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
+    "get-source": ["get-source@2.0.12", "", { "dependencies": { "data-uri-to-buffer": "^2.0.0", "source-map": "^0.6.1" } }, "sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w=="],
+
+    "glob-to-regexp": ["glob-to-regexp@0.4.1", "", {}, "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="],
+
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
     "he": ["he@1.2.0", "", { "bin": { "he": "bin/he" } }, "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="],
+
+    "hono": ["hono@4.12.12", "", {}, "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q=="],
 
     "hookable": ["hookable@5.5.3", "", {}, "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ=="],
 
@@ -388,6 +517,8 @@
     "index-to-position": ["index-to-position@1.2.0", "", {}, "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw=="],
 
     "ipv6-normalize": ["ipv6-normalize@1.0.1", "", {}, "sha512-Bm6H79i01DjgGTCWjUuCjJ6QDo1HB96PT/xCYuyJUP9WFbVDrLSbG4EZCvOCun2rNswZb0c3e4Jt/ws795esHA=="],
+
+    "is-arrayish": ["is-arrayish@0.3.4", "", {}, "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA=="],
 
     "is-core-module": ["is-core-module@2.16.1", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w=="],
 
@@ -443,13 +574,21 @@
 
     "locate-character": ["locate-character@3.0.0", "", {}, "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="],
 
+    "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
+
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "mailparser": ["mailparser@3.9.1", "", { "dependencies": { "@zone-eu/mailsplit": "5.4.8", "encoding-japanese": "2.2.0", "he": "1.2.0", "html-to-text": "9.0.5", "iconv-lite": "0.7.0", "libmime": "5.3.7", "linkify-it": "5.0.0", "nodemailer": "7.0.11", "punycode.js": "2.3.1", "tlds": "1.261.0" } }, "sha512-6vHZcco3fWsDMkf4Vz9iAfxvwrKNGbHx0dV1RKVphQ/zaNY34Buc7D37LSa09jeSeybWzYcTPjhiZFxzVRJedA=="],
 
     "memoirist": ["memoirist@0.4.0", "", {}, "sha512-zxTgA0mSYELa66DimuNQDvyLq36AwDlTuVRbnQtB+VuTcKWm5Qc4z3WkSpgsFWHNhexqkIooqpv4hdcqrX5Nmg=="],
 
+    "mime": ["mime@3.0.0", "", { "bin": { "mime": "cli.js" } }, "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="],
+
+    "miniflare": ["miniflare@3.20250204.1", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "acorn": "8.14.0", "acorn-walk": "8.3.2", "exit-hook": "2.2.1", "glob-to-regexp": "0.4.1", "stoppable": "1.1.0", "undici": "^5.28.4", "workerd": "1.20250204.0", "ws": "8.18.0", "youch": "3.2.3", "zod": "3.22.3" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-B4PQi/Ai4d0ZTWahQwsFe5WAfr1j8ISMYxJZTc56g2/btgbX+Go099LmojAZY/fMRLhIYsglcStW8SeW3f/afA=="],
+
     "minimatch": ["minimatch@5.1.6", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g=="],
+
+    "mlly": ["mlly@1.8.2", "", { "dependencies": { "acorn": "^8.16.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.3" } }, "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA=="],
 
     "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
 
@@ -457,11 +596,15 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "mustache": ["mustache@4.2.0", "", { "bin": { "mustache": "bin/mustache" } }, "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="],
+
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "nodemailer": ["nodemailer@7.0.11", "", {}, "sha512-gnXhNRE0FNhD7wPSCGhdNh46Hs6nm+uTyg+Kq0cZukNQiYdnCsoQjodNP9BQVG9XrcK/v6/MgpAPBUFyzh9pvw=="],
 
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
+
+    "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
 
     "openapi-fetch": ["openapi-fetch@0.15.0", "", { "dependencies": { "openapi-typescript-helpers": "^0.0.15" } }, "sha512-OjQUdi61WO4HYhr9+byCPMj0+bgste/LtSBEcV6FzDdONTs7x0fWn8/ndoYwzqCsKWIxEZwo4FN/TG1c1rI8IQ=="],
 
@@ -477,7 +620,11 @@
 
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
 
+    "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
+
     "pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
+
+    "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
 
     "peberminta": ["peberminta@0.9.0", "", {}, "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ=="],
 
@@ -485,13 +632,21 @@
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
+    "pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
+
     "pluralize": ["pluralize@8.0.0", "", {}, "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="],
 
+    "postal-mime": ["postal-mime@2.7.4", "", {}, "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g=="],
+
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
+
+    "printable-characters": ["printable-characters@1.0.42", "", {}, "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ=="],
 
     "punycode.js": ["punycode.js@2.3.1", "", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
 
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
+
+    "regexparam": ["regexparam@3.0.0", "", {}, "sha512-RSYAtP31mvYLkAHrOlh25pCNQ5hWnT106VukGaaFfuJrZFkGRX5GhUAdPqpSDXxOhA2c4akmRuplv1mRqnBn6Q=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
@@ -499,25 +654,45 @@
 
     "rollup": ["rollup@4.57.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.57.0", "@rollup/rollup-android-arm64": "4.57.0", "@rollup/rollup-darwin-arm64": "4.57.0", "@rollup/rollup-darwin-x64": "4.57.0", "@rollup/rollup-freebsd-arm64": "4.57.0", "@rollup/rollup-freebsd-x64": "4.57.0", "@rollup/rollup-linux-arm-gnueabihf": "4.57.0", "@rollup/rollup-linux-arm-musleabihf": "4.57.0", "@rollup/rollup-linux-arm64-gnu": "4.57.0", "@rollup/rollup-linux-arm64-musl": "4.57.0", "@rollup/rollup-linux-loong64-gnu": "4.57.0", "@rollup/rollup-linux-loong64-musl": "4.57.0", "@rollup/rollup-linux-ppc64-gnu": "4.57.0", "@rollup/rollup-linux-ppc64-musl": "4.57.0", "@rollup/rollup-linux-riscv64-gnu": "4.57.0", "@rollup/rollup-linux-riscv64-musl": "4.57.0", "@rollup/rollup-linux-s390x-gnu": "4.57.0", "@rollup/rollup-linux-x64-gnu": "4.57.0", "@rollup/rollup-linux-x64-musl": "4.57.0", "@rollup/rollup-openbsd-x64": "4.57.0", "@rollup/rollup-openharmony-arm64": "4.57.0", "@rollup/rollup-win32-arm64-msvc": "4.57.0", "@rollup/rollup-win32-ia32-msvc": "4.57.0", "@rollup/rollup-win32-x64-gnu": "4.57.0", "@rollup/rollup-win32-x64-msvc": "4.57.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-e5lPJi/aui4TO1LpAXIRLySmwXSE8k3b9zoGfd42p67wzxog4WHjiZF3M2uheQih4DGyc25QEV4yRBbpueNiUA=="],
 
+    "rollup-plugin-inject": ["rollup-plugin-inject@3.0.2", "", { "dependencies": { "estree-walker": "^0.6.1", "magic-string": "^0.25.3", "rollup-pluginutils": "^2.8.1" } }, "sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w=="],
+
+    "rollup-plugin-node-polyfills": ["rollup-plugin-node-polyfills@0.2.1", "", { "dependencies": { "rollup-plugin-inject": "^3.0.0" } }, "sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA=="],
+
+    "rollup-pluginutils": ["rollup-pluginutils@2.8.2", "", { "dependencies": { "estree-walker": "^0.6.1" } }, "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ=="],
+
     "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "selderee": ["selderee@0.11.0", "", { "dependencies": { "parseley": "^0.12.0" } }, "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA=="],
 
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
 
+    "sharp": ["sharp@0.33.5", "", { "dependencies": { "color": "^4.2.3", "detect-libc": "^2.0.3", "semver": "^7.6.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.33.5", "@img/sharp-darwin-x64": "0.33.5", "@img/sharp-libvips-darwin-arm64": "1.0.4", "@img/sharp-libvips-darwin-x64": "1.0.4", "@img/sharp-libvips-linux-arm": "1.0.5", "@img/sharp-libvips-linux-arm64": "1.0.4", "@img/sharp-libvips-linux-s390x": "1.0.4", "@img/sharp-libvips-linux-x64": "1.0.4", "@img/sharp-libvips-linuxmusl-arm64": "1.0.4", "@img/sharp-libvips-linuxmusl-x64": "1.0.4", "@img/sharp-linux-arm": "0.33.5", "@img/sharp-linux-arm64": "0.33.5", "@img/sharp-linux-s390x": "0.33.5", "@img/sharp-linux-x64": "0.33.5", "@img/sharp-linuxmusl-arm64": "0.33.5", "@img/sharp-linuxmusl-x64": "0.33.5", "@img/sharp-wasm32": "0.33.5", "@img/sharp-win32-ia32": "0.33.5", "@img/sharp-win32-x64": "0.33.5" } }, "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw=="],
+
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "simple-swizzle": ["simple-swizzle@0.2.4", "", { "dependencies": { "is-arrayish": "^0.3.1" } }, "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw=="],
 
     "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
 
     "smtp-server": ["smtp-server@3.18.0", "", { "dependencies": { "base32.js": "0.1.0", "ipv6-normalize": "1.0.1", "nodemailer": "7.0.11", "punycode.js": "2.3.1" } }, "sha512-xINTnh0H8JDAKOAGSnFX8mgXB/L4Oz8dG4P0EgKAzJEszngxEEx4vOys+yNpsUc6yIyTKS8m2BcIffq4Htma/w=="],
 
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "sourcemap-codec": ["sourcemap-codec@1.4.8", "", {}, "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="],
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
+    "stacktracey": ["stacktracey@2.2.0", "", { "dependencies": { "as-table": "^1.0.36", "get-source": "^2.0.12" } }, "sha512-ETyQEz+CzXiLjEbyJqpbp+/T79RQD/6wqFucRBIlVNZfYq2Ay7wbretD4cxpbymZlaPWx58aIhPEY1Cr8DlVvg=="],
+
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "stoppable": ["stoppable@1.1.0", "", {}, "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw=="],
 
     "strtok3": ["strtok3@10.3.4", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg=="],
 
@@ -535,11 +710,15 @@
 
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
-    "tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
+    "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
 
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
-    "tinyrainbow": ["tinyrainbow@3.0.3", "", {}, "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q=="],
+    "tinypool": ["tinypool@1.1.1", "", {}, "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg=="],
+
+    "tinyrainbow": ["tinyrainbow@1.2.0", "", {}, "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ=="],
+
+    "tinyspy": ["tinyspy@3.0.2", "", {}, "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q=="],
 
     "tlds": ["tlds@1.261.0", "", { "bin": { "tlds": "bin.js" } }, "sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA=="],
 
@@ -547,27 +726,47 @@
 
     "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
 
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
     "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
 
+    "ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
+
     "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
+
+    "undici": ["undici@5.29.0", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
+    "unenv": ["unenv@2.0.0-rc.14", "", { "dependencies": { "defu": "^6.1.4", "exsolve": "^1.0.1", "ohash": "^2.0.10", "pathe": "^2.0.3", "ufo": "^1.5.4" } }, "sha512-od496pShMen7nOy5VmVJCnq8rptd45vh6Nx/r2iPbrba6pa6p+tS2ywuIHRZ/OBvSbQZB0kWvpO9XBNVFXHD3Q=="],
+
     "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
+
+    "vite-node": ["vite-node@2.1.9", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.3.7", "es-module-lexer": "^1.5.4", "pathe": "^1.1.2", "vite": "^5.0.0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA=="],
 
     "vitefu": ["vitefu@1.1.1", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0" }, "optionalPeers": ["vite"] }, "sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ=="],
 
-    "vitest": ["vitest@4.0.18", "", { "dependencies": { "@vitest/expect": "4.0.18", "@vitest/mocker": "4.0.18", "@vitest/pretty-format": "4.0.18", "@vitest/runner": "4.0.18", "@vitest/snapshot": "4.0.18", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.18", "@vitest/browser-preview": "4.0.18", "@vitest/browser-webdriverio": "4.0.18", "@vitest/ui": "4.0.18", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ=="],
+    "vitest": ["vitest@2.1.9", "", { "dependencies": { "@vitest/expect": "2.1.9", "@vitest/mocker": "2.1.9", "@vitest/pretty-format": "^2.1.9", "@vitest/runner": "2.1.9", "@vitest/snapshot": "2.1.9", "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "debug": "^4.3.7", "expect-type": "^1.1.0", "magic-string": "^0.30.12", "pathe": "^1.1.2", "std-env": "^3.8.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.1", "tinypool": "^1.0.1", "tinyrainbow": "^1.2.0", "vite": "^5.0.0", "vite-node": "2.1.9", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/node": "^18.0.0 || >=20.0.0", "@vitest/browser": "2.1.9", "@vitest/ui": "2.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q=="],
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "workerd": ["workerd@1.20250718.0", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20250718.0", "@cloudflare/workerd-darwin-arm64": "1.20250718.0", "@cloudflare/workerd-linux-64": "1.20250718.0", "@cloudflare/workerd-linux-arm64": "1.20250718.0", "@cloudflare/workerd-windows-64": "1.20250718.0" }, "bin": { "workerd": "bin/workerd" } }, "sha512-kqkIJP/eOfDlUyBzU7joBg+tl8aB25gEAGqDap+nFWb+WHhnooxjGHgxPBy3ipw2hnShPFNOQt5lFRxbwALirg=="],
+
+    "worktop": ["worktop@0.8.0-next.18", "", { "dependencies": { "mrmime": "^2.0.0", "regexparam": "^3.0.0" } }, "sha512-+TvsA6VAVoMC3XDKR5MoC/qlLqDixEfOBysDEKnPIPou/NvoPWCAuXHXMsswwlvmEuvX56lQjvELLyLuzTKvRw=="],
+
+    "wrangler": ["wrangler@3.114.17", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.3.4", "@cloudflare/unenv-preset": "2.0.2", "@esbuild-plugins/node-globals-polyfill": "0.2.3", "@esbuild-plugins/node-modules-polyfill": "0.2.2", "blake3-wasm": "2.1.5", "esbuild": "0.17.19", "miniflare": "3.20250718.3", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.14", "workerd": "1.20250718.0" }, "optionalDependencies": { "fsevents": "~2.3.2", "sharp": "^0.33.5" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20250408.0" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-tAvf7ly+tB+zwwrmjsCyJ2pJnnc7SZhbnNwXbH+OIdVas3zTSmjcZOjmLKcGGptssAA3RyTKhcF9BvKZzMUycA=="],
+
+    "ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
 
     "yaml-ast-parser": ["yaml-ast-parser@0.0.43", "", {}, "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A=="],
 
     "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
+    "youch": ["youch@3.2.3", "", { "dependencies": { "cookie": "^0.5.0", "mustache": "^4.2.0", "stacktracey": "^2.1.8" } }, "sha512-ZBcWz/uzZaQVdCvfV4uk616Bbpf2ee+F/AvuKDR5EwX/Y4v06xWdtMluqTD7+KlZdM93lLm9gMZYo0sKBS0pgw=="],
 
     "zhead": ["zhead@2.2.4", "", {}, "sha512-8F0OI5dpWIA5IGG5NHUg9staDwz/ZPxZtvGVf01j7vHqSyZ0raHY+78atOVxRqb73AotX22uV1pXt3gYSstGag=="],
 
@@ -575,11 +774,23 @@
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
+    "@cloakmail/web/vitest": ["vitest@4.0.18", "", { "dependencies": { "@vitest/expect": "4.0.18", "@vitest/mocker": "4.0.18", "@vitest/pretty-format": "4.0.18", "@vitest/runner": "4.0.18", "@vitest/snapshot": "4.0.18", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.18", "@vitest/browser-preview": "4.0.18", "@vitest/browser-webdriverio": "4.0.18", "@vitest/ui": "4.0.18", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler": ["wrangler@3.109.1", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.3.4", "@esbuild-plugins/node-globals-polyfill": "0.2.3", "@esbuild-plugins/node-modules-polyfill": "0.2.2", "blake3-wasm": "2.1.5", "esbuild": "0.17.19", "miniflare": "3.20250204.1", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.1", "workerd": "1.20250204.0" }, "optionalDependencies": { "fsevents": "~2.3.2", "sharp": "^0.33.5" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20250204.0" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-1Jx+nZ6eCXPQ2rsGdrV6Qy/LGvhpqudeuTl4AYHl9P8Zugp44Uzxnj5w11qF4v/rv1dOZoA5TydSt9xMFfhpKg=="],
+
+    "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
+
+    "@rollup/plugin-commonjs/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
     "@rollup/plugin-commonjs/is-reference": ["is-reference@1.2.1", "", { "dependencies": { "@types/estree": "*" } }, "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ=="],
+
+    "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "@scalar/themes/@scalar/types": ["@scalar/types@0.1.7", "", { "dependencies": { "@scalar/openapi-types": "0.2.0", "@unhead/schema": "^1.11.11", "nanoid": "^5.1.5", "type-fest": "^4.20.0", "zod": "^3.23.8" } }, "sha512-irIDYzTQG2KLvFbuTI8k2Pz/R4JR+zUUSykVTbEMatkzMmVFnn1VzNSMlODbadycwZunbnL2tA27AXed9URVjw=="],
 
     "@sveltejs/kit/cookie": ["cookie@0.6.0", "", {}, "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw=="],
+
+    "@sveltejs/kit/devalue": ["devalue@5.6.2", "", {}, "sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 
@@ -593,18 +804,238 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "@vitest/mocker/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
-
-    "@vitest/runner/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
-
-    "@vitest/snapshot/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
-
     "mailparser/iconv-lite": ["iconv-lite@0.7.0", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ=="],
 
-    "vitest/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+    "miniflare/acorn": ["acorn@8.14.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA=="],
+
+    "miniflare/workerd": ["workerd@1.20250204.0", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20250204.0", "@cloudflare/workerd-darwin-arm64": "1.20250204.0", "@cloudflare/workerd-linux-64": "1.20250204.0", "@cloudflare/workerd-linux-arm64": "1.20250204.0", "@cloudflare/workerd-windows-64": "1.20250204.0" }, "bin": { "workerd": "bin/workerd" } }, "sha512-zcKufjVFsQMiD3/acg1Ix00HIMCkXCrDxQXYRDn/1AIz3QQGkmbVDwcUk1Ki2jBUoXmBCMsJdycRucgMVEypWg=="],
+
+    "miniflare/zod": ["zod@3.22.3", "", {}, "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug=="],
+
+    "mlly/acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
+
+    "mlly/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "pkg-types/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "rollup-plugin-inject/estree-walker": ["estree-walker@0.6.1", "", {}, "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w=="],
+
+    "rollup-plugin-inject/magic-string": ["magic-string@0.25.9", "", { "dependencies": { "sourcemap-codec": "^1.4.8" } }, "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ=="],
+
+    "rollup-pluginutils/estree-walker": ["estree-walker@0.6.1", "", {}, "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w=="],
+
+    "svelte/devalue": ["devalue@5.6.2", "", {}, "sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg=="],
+
+    "unenv/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "vite/esbuild": ["esbuild@0.27.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.2", "@esbuild/android-arm": "0.27.2", "@esbuild/android-arm64": "0.27.2", "@esbuild/android-x64": "0.27.2", "@esbuild/darwin-arm64": "0.27.2", "@esbuild/darwin-x64": "0.27.2", "@esbuild/freebsd-arm64": "0.27.2", "@esbuild/freebsd-x64": "0.27.2", "@esbuild/linux-arm": "0.27.2", "@esbuild/linux-arm64": "0.27.2", "@esbuild/linux-ia32": "0.27.2", "@esbuild/linux-loong64": "0.27.2", "@esbuild/linux-mips64el": "0.27.2", "@esbuild/linux-ppc64": "0.27.2", "@esbuild/linux-riscv64": "0.27.2", "@esbuild/linux-s390x": "0.27.2", "@esbuild/linux-x64": "0.27.2", "@esbuild/netbsd-arm64": "0.27.2", "@esbuild/netbsd-x64": "0.27.2", "@esbuild/openbsd-arm64": "0.27.2", "@esbuild/openbsd-x64": "0.27.2", "@esbuild/openharmony-arm64": "0.27.2", "@esbuild/sunos-x64": "0.27.2", "@esbuild/win32-arm64": "0.27.2", "@esbuild/win32-ia32": "0.27.2", "@esbuild/win32-x64": "0.27.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw=="],
+
+    "vite-node/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
+
+    "vitest/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
+
+    "wrangler/miniflare": ["miniflare@3.20250718.3", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "acorn": "8.14.0", "acorn-walk": "8.3.2", "exit-hook": "2.2.1", "glob-to-regexp": "0.4.1", "stoppable": "1.1.0", "undici": "^5.28.5", "workerd": "1.20250718.0", "ws": "8.18.0", "youch": "3.3.4", "zod": "3.22.3" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-JuPrDJhwLrNLEJiNLWO7ZzJrv/Vv9kZuwMYCfv0LskQDM6Eonw4OvywO3CH/wCGjgHzha/qyjUh8JQ068TjDgQ=="],
+
+    "youch/cookie": ["cookie@0.5.0", "", {}, "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="],
+
+    "@cloakmail/web/vitest/@vitest/expect": ["@vitest/expect@4.0.18", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "chai": "^6.2.1", "tinyrainbow": "^3.0.3" } }, "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ=="],
+
+    "@cloakmail/web/vitest/@vitest/mocker": ["@vitest/mocker@4.0.18", "", { "dependencies": { "@vitest/spy": "4.0.18", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ=="],
+
+    "@cloakmail/web/vitest/@vitest/pretty-format": ["@vitest/pretty-format@4.0.18", "", { "dependencies": { "tinyrainbow": "^3.0.3" } }, "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw=="],
+
+    "@cloakmail/web/vitest/@vitest/runner": ["@vitest/runner@4.0.18", "", { "dependencies": { "@vitest/utils": "4.0.18", "pathe": "^2.0.3" } }, "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw=="],
+
+    "@cloakmail/web/vitest/@vitest/snapshot": ["@vitest/snapshot@4.0.18", "", { "dependencies": { "@vitest/pretty-format": "4.0.18", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA=="],
+
+    "@cloakmail/web/vitest/@vitest/spy": ["@vitest/spy@4.0.18", "", {}, "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw=="],
+
+    "@cloakmail/web/vitest/@vitest/utils": ["@vitest/utils@4.0.18", "", { "dependencies": { "@vitest/pretty-format": "4.0.18", "tinyrainbow": "^3.0.3" } }, "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA=="],
+
+    "@cloakmail/web/vitest/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "@cloakmail/web/vitest/tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
+
+    "@cloakmail/web/vitest/tinyrainbow": ["tinyrainbow@3.0.3", "", {}, "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/unenv": ["unenv@2.0.0-rc.1", "", { "dependencies": { "defu": "^6.1.4", "mlly": "^1.7.4", "ohash": "^1.1.4", "pathe": "^1.1.2", "ufo": "^1.5.4" } }, "sha512-PU5fb40H8X149s117aB4ytbORcCvlASdtF97tfls4BPIyj4PeVxvpSuy1jAptqYHqB0vb2w2sHvzM0XWcp2OKg=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/workerd": ["workerd@1.20250204.0", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20250204.0", "@cloudflare/workerd-darwin-arm64": "1.20250204.0", "@cloudflare/workerd-linux-64": "1.20250204.0", "@cloudflare/workerd-linux-arm64": "1.20250204.0", "@cloudflare/workerd-windows-64": "1.20250204.0" }, "bin": { "workerd": "bin/workerd" } }, "sha512-zcKufjVFsQMiD3/acg1Ix00HIMCkXCrDxQXYRDn/1AIz3QQGkmbVDwcUk1Ki2jBUoXmBCMsJdycRucgMVEypWg=="],
 
     "@scalar/themes/@scalar/types/@scalar/openapi-types": ["@scalar/openapi-types@0.2.0", "", { "dependencies": { "zod": "^3.23.8" } }, "sha512-waiKk12cRCqyUCWTOX0K1WEVX46+hVUK+zRPzAahDJ7G0TApvbNkuy5wx7aoUyEk++HHde0XuQnshXnt8jsddA=="],
 
     "@scalar/themes/@scalar/types/nanoid": ["nanoid@5.1.6", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg=="],
+
+    "miniflare/workerd/@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20250204.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-HpsgbWEfvdcwuZ8WAZhi1TlSCyyHC3tbghpKsOqGDaQNltyAFAWqa278TPNfcitYf/FmV4961v3eqUE+RFdHNQ=="],
+
+    "miniflare/workerd/@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20250204.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-AJ8Tk7KMJqePlch3SH8oL41ROtsrb07hKRHD6M+FvGC3tLtf26rpteAAMNYKMDYKzFNFUIKZNijYDFZjBFndXQ=="],
+
+    "miniflare/workerd/@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20250204.0", "", { "os": "linux", "cpu": "x64" }, "sha512-RIUfUSnDC8h73zAa+u1K2Frc7nc+eeQoBBP7SaqsRe6JdX8jfIv/GtWjQWCoj8xQFgLvhpJKZ4sTTTV+AilQbw=="],
+
+    "miniflare/workerd/@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20250204.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-8Ql8jDjoIgr2J7oBD01kd9kduUz60njofrBpAOkjCPed15He8e8XHkYaYow3g0xpae4S2ryrPOeoD3M64sRxeg=="],
+
+    "miniflare/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20250204.0", "", { "os": "win32", "cpu": "x64" }, "sha512-RpDJO3+to+e17X3EWfRCagboZYwBz2fowc+jL53+fd7uD19v3F59H48lw2BDpHJMRyhg6ouWcpM94OhsHv8ecA=="],
+
+    "vite-node/vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
+
+    "vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.2", "", { "os": "android", "cpu": "arm" }, "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA=="],
+
+    "vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.2", "", { "os": "android", "cpu": "arm64" }, "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA=="],
+
+    "vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.2", "", { "os": "android", "cpu": "x64" }, "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A=="],
+
+    "vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg=="],
+
+    "vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA=="],
+
+    "vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g=="],
+
+    "vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA=="],
+
+    "vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.2", "", { "os": "linux", "cpu": "arm" }, "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw=="],
+
+    "vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw=="],
+
+    "vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.2", "", { "os": "linux", "cpu": "ia32" }, "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w=="],
+
+    "vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.2", "", { "os": "linux", "cpu": "none" }, "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg=="],
+
+    "vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.2", "", { "os": "linux", "cpu": "none" }, "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw=="],
+
+    "vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ=="],
+
+    "vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.2", "", { "os": "linux", "cpu": "none" }, "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA=="],
+
+    "vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w=="],
+
+    "vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.2", "", { "os": "linux", "cpu": "x64" }, "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA=="],
+
+    "vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.2", "", { "os": "none", "cpu": "x64" }, "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA=="],
+
+    "vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg=="],
+
+    "vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg=="],
+
+    "vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg=="],
+
+    "vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ=="],
+
+    "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.2", "", { "os": "win32", "cpu": "x64" }, "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ=="],
+
+    "vitest/vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
+
+    "wrangler/miniflare/acorn": ["acorn@8.14.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA=="],
+
+    "wrangler/miniflare/youch": ["youch@3.3.4", "", { "dependencies": { "cookie": "^0.7.1", "mustache": "^4.2.0", "stacktracey": "^2.1.8" } }, "sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg=="],
+
+    "wrangler/miniflare/zod": ["zod@3.22.3", "", {}, "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug=="],
+
+    "@cloakmail/web/vitest/@vitest/expect/chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/unenv/ohash": ["ohash@1.1.6", "", {}, "sha512-TBu7PtV8YkAZn0tSxobKY2n2aAQva936lhRrj6957aDaCf9IEtqsKbgMzXE/F/sjqYOwmrukeORHNLe5glk7Cg=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/workerd/@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20250204.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-HpsgbWEfvdcwuZ8WAZhi1TlSCyyHC3tbghpKsOqGDaQNltyAFAWqa278TPNfcitYf/FmV4961v3eqUE+RFdHNQ=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/workerd/@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20250204.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-AJ8Tk7KMJqePlch3SH8oL41ROtsrb07hKRHD6M+FvGC3tLtf26rpteAAMNYKMDYKzFNFUIKZNijYDFZjBFndXQ=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/workerd/@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20250204.0", "", { "os": "linux", "cpu": "x64" }, "sha512-RIUfUSnDC8h73zAa+u1K2Frc7nc+eeQoBBP7SaqsRe6JdX8jfIv/GtWjQWCoj8xQFgLvhpJKZ4sTTTV+AilQbw=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/workerd/@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20250204.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-8Ql8jDjoIgr2J7oBD01kd9kduUz60njofrBpAOkjCPed15He8e8XHkYaYow3g0xpae4S2ryrPOeoD3M64sRxeg=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20250204.0", "", { "os": "win32", "cpu": "x64" }, "sha512-RpDJO3+to+e17X3EWfRCagboZYwBz2fowc+jL53+fd7uD19v3F59H48lw2BDpHJMRyhg6ouWcpM94OhsHv8ecA=="],
+
+    "vite-node/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
+
+    "vite-node/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
+
+    "vite-node/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
+
+    "vite-node/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
+
+    "vite-node/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
+
+    "vite-node/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
+
+    "vite-node/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
+
+    "vite-node/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
+
+    "vite-node/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
+
+    "vite-node/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
+
+    "vite-node/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
+
+    "vitest/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
+
+    "vitest/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
+
+    "vitest/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
+
+    "vitest/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
+
+    "vitest/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
+
+    "vitest/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
+
+    "vitest/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
+
+    "vitest/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
+
+    "vitest/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
+
+    "vitest/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
+
+    "vitest/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
+
+    "vitest/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
+
+    "vitest/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
+
+    "vitest/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
+
+    "wrangler/miniflare/youch/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     ports:
       - "5173:5173"
     environment:
-      - PUBLIC_API_URL=http://server:3000
+      - PUBLIC_API_URL=${API_URL:-http://server:3000}
       - PUBLIC_APP_NAME=${APP_NAME:-CloakMail}
       - PUBLIC_EMAIL_DOMAIN=${DOMAIN:-localhost}
       - PORT=5173

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "cloakmail",
+  "version": "1.1.0",
   "private": true,
   "workspaces": ["packages/*"]
 }

--- a/packages/cloudflare/.cli-manifest.json
+++ b/packages/cloudflare/.cli-manifest.json
@@ -1,0 +1,10 @@
+{
+  "cloakmail_version": "1.1.0",
+  "min_cli_version": "0.1.0",
+  "templates": {
+    "api_wrangler_toml": "packages/cloudflare/wrangler.toml.template",
+    "web_wrangler_toml": "packages/web/wrangler.toml.template"
+  },
+  "migrations": "packages/cloudflare/migrations",
+  "deployable_packages": ["packages/cloudflare", "packages/web"]
+}

--- a/packages/cloudflare/.dev.vars.example
+++ b/packages/cloudflare/.dev.vars.example
@@ -1,0 +1,5 @@
+# Local dev secrets template for `wrangler dev --local`.
+# Copy to .dev.vars (gitignored) and adjust as needed.
+DOMAIN="localhost"
+EMAIL_TTL_SECONDS="86400"
+MAX_EMAIL_SIZE_MB="10"

--- a/packages/cloudflare/.gitignore
+++ b/packages/cloudflare/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+.wrangler
+wrangler.toml
+.dev.vars
+dist
+.DS_Store

--- a/packages/cloudflare/migrations/0001_init.sql
+++ b/packages/cloudflare/migrations/0001_init.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS emails (
+  id              TEXT PRIMARY KEY,
+  address         TEXT NOT NULL,
+  from_addr       TEXT NOT NULL,
+  subject         TEXT NOT NULL,
+  text_body       TEXT NOT NULL DEFAULT '',
+  html_body       TEXT NOT NULL DEFAULT '',
+  text_preview    TEXT NOT NULL DEFAULT '',
+  html_preview    TEXT NOT NULL DEFAULT '',
+  headers_json    TEXT NOT NULL DEFAULT '{}',
+  received_at_ms  INTEGER NOT NULL,
+  received_at_iso TEXT NOT NULL,
+  expires_at_ms   INTEGER NOT NULL,
+  has_r2          INTEGER NOT NULL DEFAULT 0,
+  r2_key          TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_emails_address_received ON emails(address, received_at_ms DESC);
+CREATE INDEX IF NOT EXISTS idx_emails_expires ON emails(expires_at_ms);

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@cloakmail/cloudflare",
+  "version": "1.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev --local",
+    "deploy": "wrangler deploy",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "migrate:local": "wrangler d1 migrations apply DB --local",
+    "migrate:remote": "wrangler d1 migrations apply DB --remote"
+  },
+  "dependencies": {
+    "hono": "^4.6.14",
+    "postal-mime": "^2.4.3"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250109.0",
+    "@cloudflare/vitest-pool-workers": "^0.6.0",
+    "typescript": "^5.7.0",
+    "vitest": "~2.1.9",
+    "wrangler": "^3.99.0"
+  }
+}

--- a/packages/cloudflare/src/api.ts
+++ b/packages/cloudflare/src/api.ts
@@ -1,0 +1,81 @@
+import { Hono } from "hono";
+import type { Env } from "./types";
+import {
+  deleteEmail,
+  deleteInbox,
+  getEmail,
+  getInbox,
+  isHealthy,
+} from "./store";
+
+/**
+ * Captured at module load (per-isolate) so we can report a Worker uptime
+ * that's compatible with the Docker server's `process.uptime()` field.
+ * The number resets per cold start, which is the closest analog Workers
+ * can offer.
+ */
+const BOOT_TIME_MS = Date.now();
+
+/**
+ * The Hono app exposes the same five routes as the Elysia API in
+ * `packages/server/src/api.ts`. Path, method, params, query, and response
+ * shapes match 1:1 so the existing OpenAPI types in
+ * `packages/web/src/lib/types/api.d.ts` keep working without regeneration.
+ */
+export function createApiApp(): Hono<{ Bindings: Env }> {
+  const app = new Hono<{ Bindings: Env }>();
+
+  app.get("/api/inbox/:address", async (c) => {
+    const address = c.req.param("address");
+    const page = Number(c.req.query("page")) || 1;
+    const limit = Math.min(Number(c.req.query("limit")) || 10, 50);
+    const result = await getInbox(c.env, address, page, limit);
+    return c.json(result);
+  });
+
+  app.get("/api/email/:id", async (c) => {
+    const id = c.req.param("id");
+    const email = await getEmail(c.env, id);
+    if (!email) {
+      return c.json({ error: "Email not found" }, 404);
+    }
+    return c.json(email);
+  });
+
+  app.delete("/api/inbox/:address", async (c) => {
+    const address = c.req.param("address");
+    const result = await deleteInbox(c.env, address);
+    return c.json(result);
+  });
+
+  app.delete("/api/email/:id", async (c) => {
+    const id = c.req.param("id");
+    const result = await deleteEmail(c.env, id);
+    return c.json(result);
+  });
+
+  app.get("/api/health", async (c) => {
+    // Workers don't have a long-lived SMTP server or `process.uptime()`,
+    // so we shim those fields:
+    //   - smtp: true — having an `email` export means Email Routing is
+    //     hooked up; from the wire's perspective that's "SMTP running".
+    //   - redis: storage backend (D1 + R2) reachable. Field name preserved
+    //     for compatibility with the Docker server's wire format.
+    //   - uptime: seconds since this isolate booted.
+    const storageOk = await isHealthy(c.env);
+    return c.json({
+      status: "ok",
+      smtp: true,
+      redis: storageOk,
+      uptime: (Date.now() - BOOT_TIME_MS) / 1000,
+    });
+  });
+
+  return app;
+}
+
+/**
+ * A pre-built default instance for `worker.ts` to delegate to. Tests can
+ * still call `createApiApp()` directly to get a fresh instance per test.
+ */
+export const apiApp = createApiApp();

--- a/packages/cloudflare/src/config.ts
+++ b/packages/cloudflare/src/config.ts
@@ -1,0 +1,21 @@
+import type { Env } from "./types";
+
+export interface CloudflareConfig {
+  domain: string;
+  emailTtlSeconds: number;
+  maxEmailSizeMb: number;
+}
+
+/**
+ * Build the runtime config for the Worker from its bindings.
+ *
+ * Defaults intentionally match `packages/server/src/config.ts` so the same
+ * environment variables produce identical behavior on Docker and Cloudflare.
+ */
+export function getConfig(env: Env): CloudflareConfig {
+  return {
+    domain: env.DOMAIN || "localhost",
+    emailTtlSeconds: Number(env.EMAIL_TTL_SECONDS) || 86400,
+    maxEmailSizeMb: Number(env.MAX_EMAIL_SIZE_MB) || 10,
+  };
+}

--- a/packages/cloudflare/src/email.ts
+++ b/packages/cloudflare/src/email.ts
@@ -1,0 +1,72 @@
+import PostalMime from "postal-mime";
+import type { Env, InboundEmail } from "./types";
+import { isSpam } from "./spam";
+import { storeEmail } from "./store";
+
+/**
+ * Cloudflare Email Routing entrypoint. Configured via `wrangler.toml` and
+ * the catch-all rule provisioned by `cloakmail-cli setup`. Reads the raw
+ * MIME body off the inbound message, runs the spam filter, and persists
+ * the result via the D1+R2 store.
+ */
+export async function handleEmail(
+  message: ForwardableEmailMessage,
+  env: Env,
+  _ctx: ExecutionContext,
+): Promise<void> {
+  // Read the raw stream into a buffer for postal-mime to parse.
+  const rawArrayBuffer = await new Response(message.raw).arrayBuffer();
+  const rawBytes = new Uint8Array(rawArrayBuffer);
+
+  let parsed: any;
+  try {
+    parsed = await PostalMime.parse(rawBytes);
+  } catch (err) {
+    console.error("[email] failed to parse MIME:", err);
+    return;
+  }
+
+  // Spam gate: drop executable attachments etc. We do this before storage
+  // so spam never lands in D1.
+  const spam = await isSpam(parsed);
+  if (spam.isSpam) {
+    console.log(`[email] dropped spam from ${message.from}: ${spam.reason}`);
+    return;
+  }
+
+  // Use the SMTP envelope (`message.to` / `message.from`) as the source of
+  // truth for the address pair. `parsed.to` / `parsed.from` come from
+  // user-controlled headers and can be spoofed or missing entirely.
+  const inbound: InboundEmail = {
+    to: message.to,
+    from: message.from,
+    subject: typeof parsed.subject === "string" ? parsed.subject : "",
+    text: typeof parsed.text === "string" ? parsed.text : "",
+    html: typeof parsed.html === "string" ? parsed.html : "",
+    headers: headersFromParsed(parsed),
+  };
+
+  await storeEmail(env, inbound);
+}
+
+/**
+ * Flatten postal-mime's parsed header list into a plain `Record<string,string>`
+ * so the wire shape matches what mailparser produces in `packages/server`.
+ * Repeated headers are joined with `, ` (the same convention as Node's
+ * built-in HTTP header collapsing) so we never lose information.
+ */
+function headersFromParsed(parsed: any): Record<string, string> {
+  const out: Record<string, string> = {};
+  const list = Array.isArray(parsed?.headers) ? parsed.headers : [];
+  for (const h of list) {
+    if (!h || typeof h.key !== "string") continue;
+    const key = h.key.toLowerCase();
+    const value = typeof h.value === "string" ? h.value : String(h.value ?? "");
+    if (out[key]) {
+      out[key] = `${out[key]}, ${value}`;
+    } else {
+      out[key] = value;
+    }
+  }
+  return out;
+}

--- a/packages/cloudflare/src/spam.ts
+++ b/packages/cloudflare/src/spam.ts
@@ -1,0 +1,23 @@
+import type { SpamResult } from "./types";
+
+const EXECUTABLE_EXTENSIONS = [
+  ".exe", ".bat", ".cmd", ".scr", ".pif", ".com",
+  ".vbs", ".js", ".wsh", ".ps1",
+];
+
+export async function isSpam(parsed: any): Promise<SpamResult> {
+  try {
+    // Check for executable attachments
+    const attachments = parsed.attachments || [];
+    for (const att of attachments) {
+      const filename = (att.filename || "").toLowerCase();
+      if (EXECUTABLE_EXTENSIONS.some((ext) => filename.endsWith(ext))) {
+        return { isSpam: true, reason: "executable attachment detected" };
+      }
+    }
+
+    return { isSpam: false, reason: null };
+  } catch {
+    return { isSpam: false, reason: null };
+  }
+}

--- a/packages/cloudflare/src/store.ts
+++ b/packages/cloudflare/src/store.ts
@@ -1,0 +1,353 @@
+import type { Env, InboundEmail, InboxResponse, StoredEmail } from "./types";
+import { getConfig } from "./config";
+import { newEmailId } from "./utils/id";
+import { shouldSpillToR2 } from "./utils/split";
+
+/**
+ * Maximum lengths of the inline previews kept in D1 when the body is spilled
+ * to R2. Reads of the inbox listing return these previews so we never have to
+ * round-trip to R2 just to render the inbox.
+ */
+const TEXT_PREVIEW_LIMIT = 512;
+const HTML_PREVIEW_LIMIT = 1024;
+
+/**
+ * R2 key for the spilled body of an email.
+ *
+ * Body objects live under `bodies/{id}.json` and are deleted alongside the
+ * row in `deleteEmail`, `deleteInbox`, and the cron `deleteExpired` sweep.
+ */
+function bodyKey(id: string): string {
+  return `bodies/${id}.json`;
+}
+
+/**
+ * Address normalization on the WRITE path: D1 stores everything lowercased
+ * so the indexes are predictable. Reads also lowercase so a user looking at
+ * `Foo@Bar.com` sees the same inbox as `foo@bar.com`.
+ */
+function normalizeAddress(address: string): string {
+  return address.toLowerCase();
+}
+
+interface EmailRow {
+  id: string;
+  address: string;
+  from_addr: string;
+  subject: string;
+  text_body: string;
+  html_body: string;
+  text_preview: string;
+  html_preview: string;
+  headers_json: string;
+  received_at_ms: number;
+  received_at_iso: string;
+  expires_at_ms: number;
+  has_r2: number;
+  r2_key: string | null;
+}
+
+/**
+ * Hydrate a `StoredEmail` from a D1 row, fetching the spilled body from R2
+ * when needed. R2 fetches are skipped when the caller only wants the inbox
+ * preview shape (we still return the previews as `text`/`html` so the wire
+ * format stays compatible with the existing OpenAPI types).
+ */
+async function rowToStoredEmail(
+  row: EmailRow,
+  env: Env,
+  hydrate: boolean,
+): Promise<StoredEmail> {
+  let text = row.text_body || "";
+  let html = row.html_body || "";
+
+  if (row.has_r2 === 1 && row.r2_key) {
+    if (hydrate) {
+      const obj = await env.R2.get(row.r2_key);
+      if (obj) {
+        try {
+          const body = (await obj.json()) as { text?: string; html?: string };
+          text = body.text ?? "";
+          html = body.html ?? "";
+        } catch {
+          // Fall back to the inline previews if the R2 object is corrupt.
+          text = row.text_preview || "";
+          html = row.html_preview || "";
+        }
+      } else {
+        text = row.text_preview || "";
+        html = row.html_preview || "";
+      }
+    } else {
+      text = row.text_preview || "";
+      html = row.html_preview || "";
+    }
+  }
+
+  let headers: Record<string, string> = {};
+  try {
+    headers = JSON.parse(row.headers_json || "{}");
+  } catch {
+    headers = {};
+  }
+
+  return {
+    id: row.id,
+    to: row.address,
+    from: row.from_addr,
+    subject: row.subject,
+    text,
+    html,
+    headers,
+    receivedAt: row.received_at_iso,
+  };
+}
+
+/**
+ * Persist an inbound email. Hot path: <100KB → single D1 INSERT, no R2 write.
+ * Spill path: D1 INSERT (with previews) + 1 R2 PUT.
+ */
+export async function storeEmail(env: Env, email: InboundEmail): Promise<string> {
+  const cfg = getConfig(env);
+  const id = newEmailId();
+  const nowMs = Date.now();
+  const nowIso = new Date(nowMs).toISOString();
+  const expiresAtMs = nowMs + cfg.emailTtlSeconds * 1000;
+  const address = normalizeAddress(email.to);
+  const headersJson = JSON.stringify(email.headers || {});
+  const text = email.text || "";
+  const html = email.html || "";
+
+  const spill = shouldSpillToR2({
+    to: email.to,
+    from: email.from,
+    subject: email.subject,
+    text,
+    html,
+    headers: email.headers || {},
+  });
+
+  if (spill) {
+    const key = bodyKey(id);
+    const payload = JSON.stringify({ text, html });
+    await env.R2.put(key, payload, {
+      httpMetadata: { contentType: "application/json" },
+    });
+    await env.DB.prepare(
+      `INSERT INTO emails (
+        id, address, from_addr, subject,
+        text_body, html_body, text_preview, html_preview,
+        headers_json, received_at_ms, received_at_iso, expires_at_ms,
+        has_r2, r2_key
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+      .bind(
+        id,
+        address,
+        email.from,
+        email.subject,
+        "",
+        "",
+        text.slice(0, TEXT_PREVIEW_LIMIT),
+        html.slice(0, HTML_PREVIEW_LIMIT),
+        headersJson,
+        nowMs,
+        nowIso,
+        expiresAtMs,
+        1,
+        key,
+      )
+      .run();
+  } else {
+    await env.DB.prepare(
+      `INSERT INTO emails (
+        id, address, from_addr, subject,
+        text_body, html_body, text_preview, html_preview,
+        headers_json, received_at_ms, received_at_iso, expires_at_ms,
+        has_r2, r2_key
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+      .bind(
+        id,
+        address,
+        email.from,
+        email.subject,
+        text,
+        html,
+        "",
+        "",
+        headersJson,
+        nowMs,
+        nowIso,
+        expiresAtMs,
+        0,
+        null,
+      )
+      .run();
+  }
+
+  return id;
+}
+
+/**
+ * Paginated inbox listing. Filters out expired rows so users never see
+ * mail that the cron sweep is about to remove.
+ */
+export async function getInbox(
+  env: Env,
+  address: string,
+  page = 1,
+  limit = 10,
+): Promise<InboxResponse> {
+  const safePage = Number.isFinite(page) && page > 0 ? Math.floor(page) : 1;
+  const safeLimit = Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : 10;
+  const normalized = normalizeAddress(address);
+  const offset = (safePage - 1) * safeLimit;
+  const nowMs = Date.now();
+
+  const totalRow = await env.DB.prepare(
+    `SELECT COUNT(*) AS c FROM emails WHERE address = ? AND expires_at_ms > ?`,
+  )
+    .bind(normalized, nowMs)
+    .first<{ c: number }>();
+  const total = totalRow?.c ?? 0;
+
+  const rowsResult = await env.DB.prepare(
+    `SELECT * FROM emails
+     WHERE address = ? AND expires_at_ms > ?
+     ORDER BY received_at_ms DESC
+     LIMIT ? OFFSET ?`,
+  )
+    .bind(normalized, nowMs, safeLimit, offset)
+    .all<EmailRow>();
+
+  const rows = rowsResult.results ?? [];
+  const emails: StoredEmail[] = [];
+  for (const row of rows) {
+    emails.push(await rowToStoredEmail(row, env, false));
+  }
+
+  return {
+    emails,
+    pagination: {
+      page: safePage,
+      limit: safeLimit,
+      totalEmails: total,
+      totalPages: total === 0 ? 0 : Math.ceil(total / safeLimit),
+      hasMore: safePage * safeLimit < total,
+    },
+  };
+}
+
+/**
+ * Fetch a single email by ID. Hydrates the body from R2 if it spilled.
+ * Returns null for unknown or expired rows.
+ */
+export async function getEmail(env: Env, id: string): Promise<StoredEmail | null> {
+  const nowMs = Date.now();
+  const row = await env.DB.prepare(
+    `SELECT * FROM emails WHERE id = ? AND expires_at_ms > ?`,
+  )
+    .bind(id, nowMs)
+    .first<EmailRow>();
+  if (!row) return null;
+  return rowToStoredEmail(row, env, true);
+}
+
+/**
+ * Delete every email for an address. Returns the number of D1 rows removed
+ * (matches the server contract). R2 spilled bodies are deleted alongside.
+ */
+export async function deleteInbox(
+  env: Env,
+  address: string,
+): Promise<{ deleted: number }> {
+  const normalized = normalizeAddress(address);
+  const rowsResult = await env.DB.prepare(
+    `SELECT id, r2_key, has_r2 FROM emails WHERE address = ?`,
+  )
+    .bind(normalized)
+    .all<{ id: string; r2_key: string | null; has_r2: number }>();
+
+  const rows = rowsResult.results ?? [];
+  if (rows.length === 0) return { deleted: 0 };
+
+  const r2Keys = rows
+    .filter((r) => r.has_r2 === 1 && r.r2_key)
+    .map((r) => r.r2_key as string);
+  if (r2Keys.length > 0) {
+    await env.R2.delete(r2Keys);
+  }
+
+  await env.DB.prepare(`DELETE FROM emails WHERE address = ?`)
+    .bind(normalized)
+    .run();
+
+  return { deleted: rows.length };
+}
+
+/**
+ * Delete a single email. Returns `{ deleted: false }` for unknown IDs to
+ * match the server contract.
+ */
+export async function deleteEmail(
+  env: Env,
+  id: string,
+): Promise<{ deleted: boolean }> {
+  const row = await env.DB.prepare(
+    `SELECT id, r2_key, has_r2 FROM emails WHERE id = ?`,
+  )
+    .bind(id)
+    .first<{ id: string; r2_key: string | null; has_r2: number }>();
+  if (!row) return { deleted: false };
+
+  if (row.has_r2 === 1 && row.r2_key) {
+    await env.R2.delete(row.r2_key);
+  }
+  await env.DB.prepare(`DELETE FROM emails WHERE id = ?`).bind(id).run();
+  return { deleted: true };
+}
+
+/**
+ * Cron sweep: drop every expired row plus its R2 body. Idempotent.
+ */
+export async function deleteExpired(env: Env): Promise<{ deleted: number }> {
+  const nowMs = Date.now();
+  const rowsResult = await env.DB.prepare(
+    `SELECT id, r2_key, has_r2 FROM emails WHERE expires_at_ms <= ?`,
+  )
+    .bind(nowMs)
+    .all<{ id: string; r2_key: string | null; has_r2: number }>();
+
+  const rows = rowsResult.results ?? [];
+  if (rows.length === 0) return { deleted: 0 };
+
+  const r2Keys = rows
+    .filter((r) => r.has_r2 === 1 && r.r2_key)
+    .map((r) => r.r2_key as string);
+  if (r2Keys.length > 0) {
+    await env.R2.delete(r2Keys);
+  }
+
+  await env.DB.prepare(`DELETE FROM emails WHERE expires_at_ms <= ?`)
+    .bind(nowMs)
+    .run();
+
+  return { deleted: rows.length };
+}
+
+/**
+ * Health check used by `/api/health`. Verifies that both D1 and R2 are
+ * reachable; the API uses this to populate the `redis` boolean in the
+ * health response (the field name is preserved for wire compatibility
+ * with the Docker server even though there is no Redis here).
+ */
+export async function isHealthy(env: Env): Promise<boolean> {
+  try {
+    await env.DB.prepare(`SELECT 1`).first();
+    await env.R2.head("__healthcheck__");
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/cloudflare/src/types.ts
+++ b/packages/cloudflare/src/types.ts
@@ -1,0 +1,39 @@
+export interface InboundEmail {
+  to: string;
+  from: string;
+  subject: string;
+  text: string;
+  html: string;
+  headers: Record<string, string>;
+}
+
+export interface StoredEmail extends InboundEmail {
+  id: string;
+  receivedAt: string;
+}
+
+export interface PaginationInfo {
+  page: number;
+  limit: number;
+  totalEmails: number;
+  totalPages: number;
+  hasMore: boolean;
+}
+
+export interface InboxResponse {
+  emails: StoredEmail[];
+  pagination: PaginationInfo;
+}
+
+export interface SpamResult {
+  isSpam: boolean;
+  reason: string | null;
+}
+
+export interface Env {
+  DB: D1Database;
+  R2: R2Bucket;
+  DOMAIN: string;
+  EMAIL_TTL_SECONDS: string;
+  MAX_EMAIL_SIZE_MB: string;
+}

--- a/packages/cloudflare/src/utils/id.ts
+++ b/packages/cloudflare/src/utils/id.ts
@@ -1,0 +1,9 @@
+/**
+ * Generate a 20-character ID for an email row.
+ *
+ * Same format as `packages/server/src/store.ts:8` so server-stored and
+ * Cloudflare-stored email IDs are indistinguishable.
+ */
+export function newEmailId(): string {
+  return crypto.randomUUID().replace(/-/g, "").slice(0, 20);
+}

--- a/packages/cloudflare/src/utils/split.ts
+++ b/packages/cloudflare/src/utils/split.ts
@@ -1,0 +1,20 @@
+import type { InboundEmail } from "../types";
+
+/**
+ * Bytes (well, characters) above which we spill the body into R2 instead of
+ * keeping it inline in D1. ~95% of temp emails are well below this so the
+ * inline path is the hot path.
+ */
+export const INLINE_THRESHOLD = 100_000;
+
+/**
+ * Decide whether the email body should spill out to R2 instead of being
+ * stored inline in D1. Pure function so the decision is testable in
+ * isolation from the store.
+ */
+export function shouldSpillToR2(email: InboundEmail): boolean {
+  const text = email.text || "";
+  const html = email.html || "";
+  const headers = email.headers || {};
+  return text.length + html.length + JSON.stringify(headers).length > INLINE_THRESHOLD;
+}

--- a/packages/cloudflare/src/worker.ts
+++ b/packages/cloudflare/src/worker.ts
@@ -1,0 +1,39 @@
+import { apiApp } from "./api";
+import { handleEmail } from "./email";
+import { deleteExpired } from "./store";
+import type { Env } from "./types";
+
+/**
+ * Cloudflare Worker entry point. Exposes:
+ *   - `fetch`: HTTPS handler delegated to the Hono API app
+ *   - `email`: inbound MIME handler for Cloudflare Email Routing
+ *   - `scheduled`: cron handler that sweeps expired rows from D1+R2
+ */
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    return apiApp.fetch(request, env, ctx);
+  },
+
+  async email(
+    message: ForwardableEmailMessage,
+    env: Env,
+    ctx: ExecutionContext,
+  ): Promise<void> {
+    await handleEmail(message, env, ctx);
+  },
+
+  async scheduled(
+    _controller: ScheduledController,
+    env: Env,
+    ctx: ExecutionContext,
+  ): Promise<void> {
+    // The cron sweep runs daily; let it finish even after the scheduled
+    // callback returns so we don't drop work mid-batch.
+    ctx.waitUntil(
+      (async () => {
+        const result = await deleteExpired(env);
+        console.log(`[scheduled] swept ${result.deleted} expired rows`);
+      })(),
+    );
+  },
+} satisfies ExportedHandler<Env>;

--- a/packages/cloudflare/test/api.test.ts
+++ b/packages/cloudflare/test/api.test.ts
@@ -1,0 +1,197 @@
+import { describe, test, expect, beforeAll, beforeEach } from "vitest";
+import { env, applyD1Migrations } from "cloudflare:test";
+import { createApiApp } from "../src/api";
+import { storeEmail } from "../src/store";
+
+const MIGRATIONS = [
+  {
+    name: "0001_init",
+    queries: [
+      `CREATE TABLE IF NOT EXISTS emails (
+        id              TEXT PRIMARY KEY,
+        address         TEXT NOT NULL,
+        from_addr       TEXT NOT NULL,
+        subject         TEXT NOT NULL,
+        text_body       TEXT NOT NULL DEFAULT '',
+        html_body       TEXT NOT NULL DEFAULT '',
+        text_preview    TEXT NOT NULL DEFAULT '',
+        html_preview    TEXT NOT NULL DEFAULT '',
+        headers_json    TEXT NOT NULL DEFAULT '{}',
+        received_at_ms  INTEGER NOT NULL,
+        received_at_iso TEXT NOT NULL,
+        expires_at_ms   INTEGER NOT NULL,
+        has_r2          INTEGER NOT NULL DEFAULT 0,
+        r2_key          TEXT
+      )`,
+      `CREATE INDEX IF NOT EXISTS idx_emails_address_received ON emails(address, received_at_ms DESC)`,
+      `CREATE INDEX IF NOT EXISTS idx_emails_expires ON emails(expires_at_ms)`,
+    ],
+  },
+];
+
+const app = createApiApp();
+
+async function call(
+  path: string,
+  init: RequestInit = {},
+): Promise<{ status: number; json: any }> {
+  const res = await app.fetch(new Request(`https://api.local${path}`, init), env);
+  let json: any = null;
+  const text = await res.text();
+  if (text) {
+    try {
+      json = JSON.parse(text);
+    } catch {
+      json = text;
+    }
+  }
+  return { status: res.status, json };
+}
+
+beforeAll(async () => {
+  await applyD1Migrations(env.DB, MIGRATIONS);
+});
+
+beforeEach(async () => {
+  await applyD1Migrations(env.DB, MIGRATIONS);
+});
+
+describe("GET /api/health", () => {
+  test("returns the wire-compatible health shape", async () => {
+    const { status, json } = await call("/api/health");
+    expect(status).toBe(200);
+    expect(json.status).toBe("ok");
+    expect(typeof json.smtp).toBe("boolean");
+    expect(json.smtp).toBe(true);
+    expect(typeof json.redis).toBe("boolean");
+    expect(typeof json.uptime).toBe("number");
+  });
+});
+
+describe("GET /api/inbox/:address", () => {
+  test("returns empty inbox for unknown address", async () => {
+    const { status, json } = await call("/api/inbox/empty@example.com");
+    expect(status).toBe(200);
+    expect(json.emails).toEqual([]);
+    expect(json.pagination.totalEmails).toBe(0);
+  });
+
+  test("returns stored emails", async () => {
+    await storeEmail(env, {
+      to: "list@example.com",
+      from: "sender@example.com",
+      subject: "Hello",
+      text: "body",
+      html: "",
+      headers: {},
+    });
+    const { status, json } = await call("/api/inbox/list@example.com");
+    expect(status).toBe(200);
+    expect(json.emails.length).toBeGreaterThanOrEqual(1);
+    expect(json.emails[0].subject).toBe("Hello");
+    expect(json.pagination.totalEmails).toBeGreaterThanOrEqual(1);
+  });
+
+  test("respects page and limit query params", async () => {
+    const address = "page@example.com";
+    for (let i = 0; i < 3; i++) {
+      await storeEmail(env, {
+        to: address,
+        from: "s@example.com",
+        subject: `n${i}`,
+        text: "",
+        html: "",
+        headers: {},
+      });
+    }
+    const { status, json } = await call(`/api/inbox/${address}?page=1&limit=2`);
+    expect(status).toBe(200);
+    expect(json.emails).toHaveLength(2);
+    expect(json.pagination.limit).toBe(2);
+    expect(json.pagination.totalEmails).toBe(3);
+    expect(json.pagination.totalPages).toBe(2);
+    expect(json.pagination.hasMore).toBe(true);
+  });
+
+  test("clamps limit to 50", async () => {
+    const { json } = await call("/api/inbox/clamp@example.com?limit=9999");
+    expect(json.pagination.limit).toBe(50);
+  });
+});
+
+describe("GET /api/email/:id", () => {
+  test("returns the stored email", async () => {
+    const id = await storeEmail(env, {
+      to: "one@example.com",
+      from: "sender@example.com",
+      subject: "Single",
+      text: "hi",
+      html: "",
+      headers: {},
+    });
+    const { status, json } = await call(`/api/email/${id}`);
+    expect(status).toBe(200);
+    expect(json.id).toBe(id);
+    expect(json.subject).toBe("Single");
+  });
+
+  test("returns 404 for unknown id", async () => {
+    const { status, json } = await call("/api/email/no-such-thing");
+    expect(status).toBe(404);
+    expect(json.error).toBe("Email not found");
+  });
+});
+
+describe("DELETE /api/email/:id", () => {
+  test("deletes a stored email", async () => {
+    const id = await storeEmail(env, {
+      to: "del@example.com",
+      from: "sender@example.com",
+      subject: "Delete me",
+      text: "",
+      html: "",
+      headers: {},
+    });
+    const { status, json } = await call(`/api/email/${id}`, { method: "DELETE" });
+    expect(status).toBe(200);
+    expect(json.deleted).toBe(true);
+
+    const after = await call(`/api/email/${id}`);
+    expect(after.status).toBe(404);
+  });
+
+  test("returns deleted: false for unknown id", async () => {
+    const { status, json } = await call("/api/email/nope", { method: "DELETE" });
+    expect(status).toBe(200);
+    expect(json.deleted).toBe(false);
+  });
+});
+
+describe("DELETE /api/inbox/:address", () => {
+  test("deletes everything for an address", async () => {
+    const address = "bulk-del@example.com";
+    await storeEmail(env, {
+      to: address,
+      from: "s@example.com",
+      subject: "A",
+      text: "",
+      html: "",
+      headers: {},
+    });
+    await storeEmail(env, {
+      to: address,
+      from: "s@example.com",
+      subject: "B",
+      text: "",
+      html: "",
+      headers: {},
+    });
+
+    const { status, json } = await call(`/api/inbox/${address}`, { method: "DELETE" });
+    expect(status).toBe(200);
+    expect(json.deleted).toBe(2);
+
+    const inbox = await call(`/api/inbox/${address}`);
+    expect(inbox.json.emails).toHaveLength(0);
+  });
+});

--- a/packages/cloudflare/test/config.test.ts
+++ b/packages/cloudflare/test/config.test.ts
@@ -1,0 +1,48 @@
+import { describe, test, expect } from "vitest";
+import { getConfig } from "../src/config";
+import type { Env } from "../src/types";
+
+function makeEnv(overrides: Partial<Env> = {}): Env {
+  return {
+    DB: {} as D1Database,
+    R2: {} as R2Bucket,
+    DOMAIN: "example.com",
+    EMAIL_TTL_SECONDS: "86400",
+    MAX_EMAIL_SIZE_MB: "10",
+    ...overrides,
+  };
+}
+
+describe("getConfig", () => {
+  test("returns domain from env", () => {
+    const cfg = getConfig(makeEnv({ DOMAIN: "cloak.example.com" }));
+    expect(cfg.domain).toBe("cloak.example.com");
+  });
+
+  test("falls back to localhost when DOMAIN is empty", () => {
+    const cfg = getConfig(makeEnv({ DOMAIN: "" }));
+    expect(cfg.domain).toBe("localhost");
+  });
+
+  test("parses emailTtlSeconds as a number", () => {
+    const cfg = getConfig(makeEnv({ EMAIL_TTL_SECONDS: "3600" }));
+    expect(typeof cfg.emailTtlSeconds).toBe("number");
+    expect(cfg.emailTtlSeconds).toBe(3600);
+  });
+
+  test("falls back to 86400 when EMAIL_TTL_SECONDS missing or invalid", () => {
+    expect(getConfig(makeEnv({ EMAIL_TTL_SECONDS: "" })).emailTtlSeconds).toBe(86400);
+    expect(getConfig(makeEnv({ EMAIL_TTL_SECONDS: "not-a-number" })).emailTtlSeconds).toBe(86400);
+  });
+
+  test("parses maxEmailSizeMb as a number", () => {
+    const cfg = getConfig(makeEnv({ MAX_EMAIL_SIZE_MB: "25" }));
+    expect(typeof cfg.maxEmailSizeMb).toBe("number");
+    expect(cfg.maxEmailSizeMb).toBe(25);
+  });
+
+  test("falls back to 10 when MAX_EMAIL_SIZE_MB missing or invalid", () => {
+    expect(getConfig(makeEnv({ MAX_EMAIL_SIZE_MB: "" })).maxEmailSizeMb).toBe(10);
+    expect(getConfig(makeEnv({ MAX_EMAIL_SIZE_MB: "junk" })).maxEmailSizeMb).toBe(10);
+  });
+});

--- a/packages/cloudflare/test/email.test.ts
+++ b/packages/cloudflare/test/email.test.ts
@@ -1,0 +1,172 @@
+import { describe, test, expect, beforeAll, beforeEach } from "vitest";
+import { env, applyD1Migrations, createExecutionContext } from "cloudflare:test";
+import { handleEmail } from "../src/email";
+
+const MIGRATIONS = [
+  {
+    name: "0001_init",
+    queries: [
+      `CREATE TABLE IF NOT EXISTS emails (
+        id              TEXT PRIMARY KEY,
+        address         TEXT NOT NULL,
+        from_addr       TEXT NOT NULL,
+        subject         TEXT NOT NULL,
+        text_body       TEXT NOT NULL DEFAULT '',
+        html_body       TEXT NOT NULL DEFAULT '',
+        text_preview    TEXT NOT NULL DEFAULT '',
+        html_preview    TEXT NOT NULL DEFAULT '',
+        headers_json    TEXT NOT NULL DEFAULT '{}',
+        received_at_ms  INTEGER NOT NULL,
+        received_at_iso TEXT NOT NULL,
+        expires_at_ms   INTEGER NOT NULL,
+        has_r2          INTEGER NOT NULL DEFAULT 0,
+        r2_key          TEXT
+      )`,
+      `CREATE INDEX IF NOT EXISTS idx_emails_address_received ON emails(address, received_at_ms DESC)`,
+      `CREATE INDEX IF NOT EXISTS idx_emails_expires ON emails(expires_at_ms)`,
+    ],
+  },
+];
+
+beforeAll(async () => {
+  await applyD1Migrations(env.DB, MIGRATIONS);
+});
+
+beforeEach(async () => {
+  await applyD1Migrations(env.DB, MIGRATIONS);
+});
+
+/**
+ * Build a stream of bytes from a UTF-8 string for the `raw` body of a fake
+ * `ForwardableEmailMessage`. The Workers API exposes `raw` as a
+ * ReadableStream<Uint8Array>, which is exactly what `new Response(...)` will
+ * accept.
+ */
+function streamFrom(str: string): ReadableStream<Uint8Array> {
+  const bytes = new TextEncoder().encode(str);
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(bytes);
+      controller.close();
+    },
+  });
+}
+
+function makeFakeMessage(opts: {
+  to: string;
+  from: string;
+  raw: string;
+}): ForwardableEmailMessage {
+  return {
+    from: opts.from,
+    to: opts.to,
+    raw: streamFrom(opts.raw),
+    rawSize: opts.raw.length,
+    headers: new Headers(),
+    setReject: () => {},
+    forward: async () => {},
+    reply: async () => {},
+  } as unknown as ForwardableEmailMessage;
+}
+
+const SAMPLE_MIME = [
+  "From: Test Sender <sender@example.com>",
+  "To: alice@cloakmail.test",
+  "Subject: Hello from MIME",
+  "Content-Type: text/plain; charset=utf-8",
+  "Message-ID: <abc@example.com>",
+  "",
+  "This is the plain-text body.",
+].join("\r\n");
+
+describe("handleEmail", () => {
+  test("parses MIME and stores a row in D1", async () => {
+    const ctx = createExecutionContext();
+    const message = makeFakeMessage({
+      to: "alice@cloakmail.test",
+      from: "sender@example.com",
+      raw: SAMPLE_MIME,
+    });
+
+    await handleEmail(message, env, ctx);
+
+    const row = await env.DB.prepare(
+      `SELECT * FROM emails WHERE address = ? ORDER BY received_at_ms DESC LIMIT 1`,
+    )
+      .bind("alice@cloakmail.test")
+      .first<any>();
+
+    expect(row).toBeTruthy();
+    expect(row.from_addr).toBe("sender@example.com");
+    expect(row.subject).toBe("Hello from MIME");
+    expect(row.text_body).toContain("plain-text body");
+    expect(row.has_r2).toBe(0);
+  });
+
+  test("uses envelope address (message.to), not parsed To header", async () => {
+    // The envelope says alice@... but the From/To headers in the MIME body
+    // claim something different. The store should record the envelope.
+    const mismatched = [
+      "From: Header-From <header@example.com>",
+      "To: header-to@example.com",
+      "Subject: Envelope wins",
+      "",
+      "body",
+    ].join("\r\n");
+
+    const ctx = createExecutionContext();
+    const message = makeFakeMessage({
+      to: "envelope@cloakmail.test",
+      from: "envelope-sender@example.com",
+      raw: mismatched,
+    });
+    await handleEmail(message, env, ctx);
+
+    const row = await env.DB.prepare(
+      `SELECT address, from_addr FROM emails WHERE subject = ?`,
+    )
+      .bind("Envelope wins")
+      .first<{ address: string; from_addr: string }>();
+    expect(row?.address).toBe("envelope@cloakmail.test");
+    expect(row?.from_addr).toBe("envelope-sender@example.com");
+  });
+
+  test("drops messages flagged as spam (executable attachments)", async () => {
+    // Multipart MIME with a .exe attachment.
+    const boundary = "===boundary===";
+    const mime = [
+      "From: bad@example.com",
+      "To: target@cloakmail.test",
+      "Subject: Spam attempt",
+      `Content-Type: multipart/mixed; boundary=${boundary}`,
+      "",
+      `--${boundary}`,
+      "Content-Type: text/plain",
+      "",
+      "Click here for free stuff",
+      `--${boundary}`,
+      "Content-Type: application/octet-stream",
+      'Content-Disposition: attachment; filename="payload.exe"',
+      "Content-Transfer-Encoding: base64",
+      "",
+      "AAAA",
+      `--${boundary}--`,
+      "",
+    ].join("\r\n");
+
+    const ctx = createExecutionContext();
+    const message = makeFakeMessage({
+      to: "target@cloakmail.test",
+      from: "bad@example.com",
+      raw: mime,
+    });
+    await handleEmail(message, env, ctx);
+
+    const row = await env.DB.prepare(
+      `SELECT id FROM emails WHERE subject = ?`,
+    )
+      .bind("Spam attempt")
+      .first<{ id: string }>();
+    expect(row).toBeNull();
+  });
+});

--- a/packages/cloudflare/test/env.d.ts
+++ b/packages/cloudflare/test/env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="@cloudflare/workers-types" />
+/// <reference types="@cloudflare/vitest-pool-workers" />
+
+import type { Env } from "../src/types";
+
+declare module "cloudflare:test" {
+  // Make `env` from `cloudflare:test` typed as the Worker's `Env`.
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  interface ProvidedEnv extends Env {}
+}

--- a/packages/cloudflare/test/spam.test.ts
+++ b/packages/cloudflare/test/spam.test.ts
@@ -1,0 +1,71 @@
+import { describe, test, expect } from "vitest";
+import { isSpam } from "../src/spam";
+
+describe("isSpam", () => {
+  test("rejects emails with .exe attachments", async () => {
+    const parsed = {
+      attachments: [{ filename: "malware.exe" }],
+    };
+    const result = await isSpam(parsed);
+    expect(result.isSpam).toBe(true);
+    expect(result.reason).toContain("executable");
+  });
+
+  test("rejects emails with .bat attachments", async () => {
+    const parsed = {
+      attachments: [{ filename: "script.bat" }],
+    };
+    const result = await isSpam(parsed);
+    expect(result.isSpam).toBe(true);
+  });
+
+  test("rejects emails with .ps1 attachments", async () => {
+    const parsed = {
+      attachments: [{ filename: "payload.ps1" }],
+    };
+    const result = await isSpam(parsed);
+    expect(result.isSpam).toBe(true);
+  });
+
+  test("rejects case-insensitive executable extensions", async () => {
+    const parsed = {
+      attachments: [{ filename: "VIRUS.EXE" }],
+    };
+    const result = await isSpam(parsed);
+    expect(result.isSpam).toBe(true);
+  });
+
+  test("allows emails without attachments", async () => {
+    const parsed = {
+      attachments: [],
+    };
+    const result = await isSpam(parsed);
+    expect(result.isSpam).toBe(false);
+    expect(result.reason).toBeNull();
+  });
+
+  test("allows emails with safe attachments", async () => {
+    const parsed = {
+      attachments: [
+        { filename: "document.pdf" },
+        { filename: "photo.png" },
+      ],
+    };
+    const result = await isSpam(parsed);
+    expect(result.isSpam).toBe(false);
+  });
+
+  test("handles missing attachments field", async () => {
+    const parsed = {};
+    const result = await isSpam(parsed);
+    expect(result.isSpam).toBe(false);
+  });
+
+  test("handles missing filename on attachment", async () => {
+    const parsed = {
+      attachments: [{}],
+    };
+    const result = await isSpam(parsed);
+    expect(result.isSpam).toBe(false);
+  });
+});

--- a/packages/cloudflare/test/split.test.ts
+++ b/packages/cloudflare/test/split.test.ts
@@ -1,0 +1,69 @@
+import { describe, test, expect } from "vitest";
+import { INLINE_THRESHOLD, shouldSpillToR2 } from "../src/utils/split";
+import type { InboundEmail } from "../src/types";
+
+function makeEmail(overrides: Partial<InboundEmail> = {}): InboundEmail {
+  return {
+    to: "to@example.com",
+    from: "from@example.com",
+    subject: "subject",
+    text: "",
+    html: "",
+    headers: {},
+    ...overrides,
+  };
+}
+
+describe("shouldSpillToR2", () => {
+  test("INLINE_THRESHOLD is 100k characters", () => {
+    expect(INLINE_THRESHOLD).toBe(100_000);
+  });
+
+  test("returns false for tiny emails", () => {
+    expect(shouldSpillToR2(makeEmail({ text: "hello", html: "<p>hi</p>" }))).toBe(false);
+  });
+
+  test("returns false at threshold boundary", () => {
+    const text = "a".repeat(50_000);
+    const html = "b".repeat(40_000);
+    // headers add ~2 chars for "{}"
+    expect(shouldSpillToR2(makeEmail({ text, html }))).toBe(false);
+  });
+
+  test("returns true when text alone exceeds threshold", () => {
+    const text = "a".repeat(INLINE_THRESHOLD + 1);
+    expect(shouldSpillToR2(makeEmail({ text }))).toBe(true);
+  });
+
+  test("returns true when html alone exceeds threshold", () => {
+    const html = "b".repeat(INLINE_THRESHOLD + 1);
+    expect(shouldSpillToR2(makeEmail({ html }))).toBe(true);
+  });
+
+  test("returns true when text + html together exceed threshold", () => {
+    const text = "a".repeat(60_000);
+    const html = "b".repeat(60_000);
+    expect(shouldSpillToR2(makeEmail({ text, html }))).toBe(true);
+  });
+
+  test("counts header JSON length toward the threshold", () => {
+    const headers: Record<string, string> = {};
+    for (let i = 0; i < 2000; i++) {
+      headers[`x-header-${i}`] = "x".repeat(60);
+    }
+    expect(shouldSpillToR2(makeEmail({ headers }))).toBe(true);
+  });
+
+  test("handles missing fields safely", () => {
+    expect(
+      shouldSpillToR2({
+        to: "a@b.c",
+        from: "c@d.e",
+        subject: "",
+        text: undefined as unknown as string,
+        html: undefined as unknown as string,
+        headers: undefined as unknown as Record<string, string>,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/cloudflare/test/store.test.ts
+++ b/packages/cloudflare/test/store.test.ts
@@ -1,0 +1,317 @@
+import { describe, test, expect, beforeAll, beforeEach } from "vitest";
+import { env, applyD1Migrations } from "cloudflare:test";
+import {
+  storeEmail,
+  getInbox,
+  getEmail,
+  deleteInbox,
+  deleteEmail,
+  deleteExpired,
+  isHealthy,
+} from "../src/store";
+import type { InboundEmail } from "../src/types";
+import { INLINE_THRESHOLD } from "../src/utils/split";
+
+const MIGRATIONS = [
+  {
+    name: "0001_init",
+    queries: [
+      `CREATE TABLE IF NOT EXISTS emails (
+        id              TEXT PRIMARY KEY,
+        address         TEXT NOT NULL,
+        from_addr       TEXT NOT NULL,
+        subject         TEXT NOT NULL,
+        text_body       TEXT NOT NULL DEFAULT '',
+        html_body       TEXT NOT NULL DEFAULT '',
+        text_preview    TEXT NOT NULL DEFAULT '',
+        html_preview    TEXT NOT NULL DEFAULT '',
+        headers_json    TEXT NOT NULL DEFAULT '{}',
+        received_at_ms  INTEGER NOT NULL,
+        received_at_iso TEXT NOT NULL,
+        expires_at_ms   INTEGER NOT NULL,
+        has_r2          INTEGER NOT NULL DEFAULT 0,
+        r2_key          TEXT
+      )`,
+      `CREATE INDEX IF NOT EXISTS idx_emails_address_received ON emails(address, received_at_ms DESC)`,
+      `CREATE INDEX IF NOT EXISTS idx_emails_expires ON emails(expires_at_ms)`,
+    ],
+  },
+];
+
+function makeEmail(overrides: Partial<InboundEmail> = {}): InboundEmail {
+  return {
+    to: "user@example.com",
+    from: "sender@example.com",
+    subject: "Test Subject",
+    text: "Test body",
+    html: "<p>Test body</p>",
+    headers: { "x-test": "true" },
+    ...overrides,
+  };
+}
+
+beforeAll(async () => {
+  await applyD1Migrations(env.DB, MIGRATIONS);
+});
+
+beforeEach(async () => {
+  // isolatedStorage rolls back D1+R2 between tests, but we still need
+  // the migrated schema to exist on each fresh storage instance.
+  await applyD1Migrations(env.DB, MIGRATIONS);
+});
+
+describe("store: storeEmail (inline path)", () => {
+  test("returns a 20-character ID", async () => {
+    const id = await storeEmail(env, makeEmail());
+    expect(typeof id).toBe("string");
+    expect(id).toHaveLength(20);
+  });
+
+  test("persists row in D1 with has_r2 = 0", async () => {
+    const id = await storeEmail(env, makeEmail({ subject: "Inline Path" }));
+    const row = await env.DB.prepare(`SELECT * FROM emails WHERE id = ?`)
+      .bind(id)
+      .first<any>();
+    expect(row).toBeTruthy();
+    expect(row.has_r2).toBe(0);
+    expect(row.r2_key).toBeNull();
+    expect(row.text_body).toBe("Test body");
+    expect(row.html_body).toBe("<p>Test body</p>");
+  });
+
+  test("normalizes address to lowercase on write", async () => {
+    const id = await storeEmail(env, makeEmail({ to: "MixedCase@EXAMPLE.com" }));
+    const row = await env.DB.prepare(`SELECT address FROM emails WHERE id = ?`)
+      .bind(id)
+      .first<{ address: string }>();
+    expect(row?.address).toBe("mixedcase@example.com");
+  });
+});
+
+describe("store: storeEmail (spill path)", () => {
+  test("spills oversized bodies to R2", async () => {
+    const text = "x".repeat(INLINE_THRESHOLD + 10);
+    const html = "<p>" + "y".repeat(INLINE_THRESHOLD) + "</p>";
+    const id = await storeEmail(env, makeEmail({ text, html }));
+
+    const row = await env.DB.prepare(`SELECT * FROM emails WHERE id = ?`)
+      .bind(id)
+      .first<any>();
+    expect(row.has_r2).toBe(1);
+    expect(row.r2_key).toBe(`bodies/${id}.json`);
+    // Inline columns are empty when spilled
+    expect(row.text_body).toBe("");
+    expect(row.html_body).toBe("");
+    // Previews populated
+    expect(row.text_preview.length).toBe(512);
+    expect(row.html_preview.length).toBe(1024);
+
+    // R2 object exists with the full body
+    const obj = await env.R2.get(`bodies/${id}.json`);
+    expect(obj).toBeTruthy();
+    const body = (await obj!.json()) as { text: string; html: string };
+    expect(body.text).toBe(text);
+    expect(body.html).toBe(html);
+  });
+});
+
+describe("store: getEmail", () => {
+  test("returns null for unknown id", async () => {
+    const result = await getEmail(env, "does-not-exist");
+    expect(result).toBeNull();
+  });
+
+  test("hydrates inline emails", async () => {
+    const id = await storeEmail(
+      env,
+      makeEmail({ subject: "Hydrate Inline", text: "abc", html: "<p>abc</p>" }),
+    );
+    const stored = await getEmail(env, id);
+    expect(stored).not.toBeNull();
+    expect(stored!.id).toBe(id);
+    expect(stored!.subject).toBe("Hydrate Inline");
+    expect(stored!.text).toBe("abc");
+    expect(stored!.html).toBe("<p>abc</p>");
+    expect(stored!.headers).toEqual({ "x-test": "true" });
+    expect(stored!.receivedAt).toBeTruthy();
+  });
+
+  test("hydrates spilled emails from R2", async () => {
+    const text = "z".repeat(INLINE_THRESHOLD + 100);
+    const id = await storeEmail(env, makeEmail({ text, html: "" }));
+    const stored = await getEmail(env, id);
+    expect(stored).not.toBeNull();
+    expect(stored!.text).toBe(text);
+  });
+
+  test("returns null for expired emails", async () => {
+    const id = await storeEmail(env, makeEmail());
+    // Force expire the row
+    await env.DB.prepare(`UPDATE emails SET expires_at_ms = ? WHERE id = ?`)
+      .bind(Date.now() - 1000, id)
+      .run();
+    const result = await getEmail(env, id);
+    expect(result).toBeNull();
+  });
+});
+
+describe("store: getInbox", () => {
+  test("returns empty for unknown address", async () => {
+    const result = await getInbox(env, "noone@example.com");
+    expect(result.emails).toHaveLength(0);
+    expect(result.pagination.totalEmails).toBe(0);
+    expect(result.pagination.totalPages).toBe(0);
+    expect(result.pagination.hasMore).toBe(false);
+  });
+
+  test("paginates by received_at desc", async () => {
+    const address = "paginate@example.com";
+    for (let i = 0; i < 3; i++) {
+      await storeEmail(env, makeEmail({ to: address, subject: `Email ${i}` }));
+      // Force monotonic timestamps so the sort is deterministic
+      await env.DB.prepare(`UPDATE emails SET received_at_ms = ? WHERE subject = ?`)
+        .bind(1_000_000 + i, `Email ${i}`)
+        .run();
+    }
+
+    const page1 = await getInbox(env, address, 1, 2);
+    expect(page1.emails).toHaveLength(2);
+    expect(page1.pagination.totalEmails).toBe(3);
+    expect(page1.pagination.totalPages).toBe(2);
+    expect(page1.pagination.hasMore).toBe(true);
+    expect(page1.emails[0].subject).toBe("Email 2");
+    expect(page1.emails[1].subject).toBe("Email 1");
+
+    const page2 = await getInbox(env, address, 2, 2);
+    expect(page2.emails).toHaveLength(1);
+    expect(page2.pagination.hasMore).toBe(false);
+    expect(page2.emails[0].subject).toBe("Email 0");
+  });
+
+  test("filters expired rows out of inbox listing", async () => {
+    const address = "expiry@example.com";
+    const idLive = await storeEmail(env, makeEmail({ to: address, subject: "Live" }));
+    const idExpired = await storeEmail(env, makeEmail({ to: address, subject: "Expired" }));
+    await env.DB.prepare(`UPDATE emails SET expires_at_ms = ? WHERE id = ?`)
+      .bind(Date.now() - 1, idExpired)
+      .run();
+
+    const result = await getInbox(env, address);
+    expect(result.emails).toHaveLength(1);
+    expect(result.emails[0].id).toBe(idLive);
+    expect(result.pagination.totalEmails).toBe(1);
+  });
+
+  test("address lookup is case-insensitive", async () => {
+    const id = await storeEmail(env, makeEmail({ to: "Casey@Example.com" }));
+    const result = await getInbox(env, "casey@example.com");
+    expect(result.emails.map((e) => e.id)).toContain(id);
+  });
+});
+
+describe("store: deleteEmail", () => {
+  test("deletes inline rows", async () => {
+    const id = await storeEmail(env, makeEmail({ subject: "Delete me" }));
+    const result = await deleteEmail(env, id);
+    expect(result.deleted).toBe(true);
+    expect(await getEmail(env, id)).toBeNull();
+  });
+
+  test("deletes spilled rows + R2 object", async () => {
+    const text = "w".repeat(INLINE_THRESHOLD + 1);
+    const id = await storeEmail(env, makeEmail({ text }));
+    const key = `bodies/${id}.json`;
+    expect(await env.R2.head(key)).toBeTruthy();
+
+    await deleteEmail(env, id);
+    expect(await env.R2.head(key)).toBeNull();
+  });
+
+  test("returns false for unknown id", async () => {
+    const result = await deleteEmail(env, "no-such-id");
+    expect(result.deleted).toBe(false);
+  });
+});
+
+describe("store: deleteInbox", () => {
+  test("removes every email for an address", async () => {
+    const address = "delete-bulk@example.com";
+    await storeEmail(env, makeEmail({ to: address, subject: "A" }));
+    await storeEmail(env, makeEmail({ to: address, subject: "B" }));
+    await storeEmail(env, makeEmail({ to: address, subject: "C" }));
+
+    const result = await deleteInbox(env, address);
+    expect(result.deleted).toBe(3);
+
+    const inbox = await getInbox(env, address);
+    expect(inbox.emails).toHaveLength(0);
+  });
+
+  test("removes spilled R2 objects too", async () => {
+    const address = "delete-spilled@example.com";
+    const text = "v".repeat(INLINE_THRESHOLD + 1);
+    const id = await storeEmail(env, makeEmail({ to: address, text }));
+    const key = `bodies/${id}.json`;
+    expect(await env.R2.head(key)).toBeTruthy();
+
+    await deleteInbox(env, address);
+    expect(await env.R2.head(key)).toBeNull();
+  });
+
+  test("returns 0 for an empty inbox", async () => {
+    const result = await deleteInbox(env, "ghost@example.com");
+    expect(result.deleted).toBe(0);
+  });
+});
+
+describe("store: deleteExpired (cron sweep)", () => {
+  test("sweeps expired rows but leaves live ones", async () => {
+    const address = "sweep@example.com";
+    const idLive = await storeEmail(env, makeEmail({ to: address, subject: "Live" }));
+    const idDead = await storeEmail(env, makeEmail({ to: address, subject: "Dead" }));
+    await env.DB.prepare(`UPDATE emails SET expires_at_ms = ? WHERE id = ?`)
+      .bind(Date.now() - 1, idDead)
+      .run();
+
+    const result = await deleteExpired(env);
+    expect(result.deleted).toBe(1);
+
+    // Live row still exists
+    const row = await env.DB.prepare(`SELECT id FROM emails WHERE id = ?`)
+      .bind(idLive)
+      .first<{ id: string }>();
+    expect(row?.id).toBe(idLive);
+
+    // Dead row gone
+    const dead = await env.DB.prepare(`SELECT id FROM emails WHERE id = ?`)
+      .bind(idDead)
+      .first<{ id: string }>();
+    expect(dead).toBeNull();
+  });
+
+  test("cleans up R2 objects of spilled expired rows", async () => {
+    const text = "u".repeat(INLINE_THRESHOLD + 1);
+    const id = await storeEmail(env, makeEmail({ text }));
+    const key = `bodies/${id}.json`;
+    expect(await env.R2.head(key)).toBeTruthy();
+
+    await env.DB.prepare(`UPDATE emails SET expires_at_ms = ? WHERE id = ?`)
+      .bind(Date.now() - 1, id)
+      .run();
+    await deleteExpired(env);
+    expect(await env.R2.head(key)).toBeNull();
+  });
+
+  test("is a no-op when nothing has expired", async () => {
+    await storeEmail(env, makeEmail());
+    const result = await deleteExpired(env);
+    expect(result.deleted).toBe(0);
+  });
+});
+
+describe("store: isHealthy", () => {
+  test("returns true with working bindings", async () => {
+    const ok = await isHealthy(env);
+    expect(ok).toBe(true);
+  });
+});

--- a/packages/cloudflare/tsconfig.json
+++ b/packages/cloudflare/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "allowJs": false,
+    "declaration": false,
+    "jsx": "react-jsx"
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "exclude": ["node_modules", "dist", ".wrangler"]
+}

--- a/packages/cloudflare/vitest.config.ts
+++ b/packages/cloudflare/vitest.config.ts
@@ -1,0 +1,29 @@
+import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineWorkersConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+    poolOptions: {
+      workers: {
+        singleWorker: true,
+        isolatedStorage: true,
+        main: path.resolve(__dirname, "src/worker.ts"),
+        miniflare: {
+          compatibilityDate: "2025-01-01",
+          compatibilityFlags: ["nodejs_compat"],
+          d1Databases: ["DB"],
+          r2Buckets: ["R2"],
+          bindings: {
+            DOMAIN: "test.local",
+            EMAIL_TTL_SECONDS: "86400",
+            MAX_EMAIL_SIZE_MB: "10",
+          },
+        },
+      },
+    },
+  },
+});

--- a/packages/cloudflare/wrangler.toml.example
+++ b/packages/cloudflare/wrangler.toml.example
@@ -1,0 +1,30 @@
+# packages/cloudflare/wrangler.toml.example
+# Static fallback for the Cloudflare Deploy Button. Copy to wrangler.toml,
+# replace D1 database_id with the value emitted by `wrangler d1 create`,
+# then run `wrangler deploy`. The recommended path is `bunx cloakmail-cli setup`,
+# which renders wrangler.toml from wrangler.toml.template instead.
+name = "cloakmail-api"
+main = "src/worker.ts"
+compatibility_date = "2025-01-01"
+compatibility_flags = ["nodejs_compat"]
+
+[triggers]
+crons = ["0 3 * * *"]
+
+[[d1_databases]]
+binding = "DB"
+database_name = "cloakmail"
+database_id = "00000000-0000-0000-0000-000000000000"
+migrations_dir = "migrations"
+
+[[r2_buckets]]
+binding = "R2"
+bucket_name = "cloakmail-bodies"
+
+[vars]
+DOMAIN = "example.com"
+EMAIL_TTL_SECONDS = "86400"
+MAX_EMAIL_SIZE_MB = "10"
+
+[observability]
+enabled = true

--- a/packages/cloudflare/wrangler.toml.template
+++ b/packages/cloudflare/wrangler.toml.template
@@ -1,0 +1,27 @@
+# packages/cloudflare/wrangler.toml.template
+# Rendered to wrangler.toml by cloakmail-cli setup. Do not edit the rendered file.
+name = "{{API_WORKER_NAME}}"
+main = "src/worker.ts"
+compatibility_date = "2025-01-01"
+compatibility_flags = ["nodejs_compat"]
+
+[triggers]
+crons = ["0 3 * * *"]
+
+[[d1_databases]]
+binding = "DB"
+database_name = "{{D1_NAME}}"
+database_id = "{{D1_ID}}"
+migrations_dir = "migrations"
+
+[[r2_buckets]]
+binding = "R2"
+bucket_name = "{{R2_NAME}}"
+
+[vars]
+DOMAIN = "{{DOMAIN}}"
+EMAIL_TTL_SECONDS = "{{EMAIL_TTL_SECONDS}}"
+MAX_EMAIL_SIZE_MB = "{{MAX_EMAIL_SIZE_MB}}"
+
+[observability]
+enabled = true

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloakmail/server",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "scripts": {
     "dev": "bun run --watch src/index.ts",

--- a/packages/web/.gitignore
+++ b/packages/web/.gitignore
@@ -6,7 +6,9 @@ node_modules
 .netlify
 .wrangler
 /.svelte-kit
+/.svelte-kit/cloudflare/
 /build
+wrangler.toml
 
 # OS
 .DS_Store

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,11 +1,13 @@
 {
 	"name": "@cloakmail/web",
 	"private": true,
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
+		"build:cloudflare": "ADAPTER=cloudflare vite build",
+		"deploy:cloudflare": "ADAPTER=cloudflare vite build && wrangler deploy",
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync || echo ''",
 		"generate:api": "openapi-typescript http://localhost:3000/swagger/json -o src/lib/types/api.d.ts",
@@ -13,6 +15,7 @@
 		"test:watch": "vitest"
 	},
 	"devDependencies": {
+		"@sveltejs/adapter-cloudflare": "^7.2.8",
 		"@sveltejs/adapter-node": "^5.5.0",
 		"@sveltejs/kit": "^2.50.1",
 		"@sveltejs/vite-plugin-svelte": "^6.2.4",

--- a/packages/web/src/hooks.server.ts
+++ b/packages/web/src/hooks.server.ts
@@ -1,0 +1,19 @@
+import type { Handle } from '@sveltejs/kit';
+
+export const handle: Handle = async ({ event, resolve }) => {
+	if (event.url.pathname.startsWith('/api/')) {
+		const api = (event.platform as any)?.env?.API;
+		if (api) {
+			// Forward via service binding. Host is irrelevant — bindings route by name.
+			const forwarded = new Request(
+				`https://api.internal${event.url.pathname}${event.url.search}`,
+				event.request,
+			);
+			return api.fetch(forwarded);
+		}
+		// adapter-node fallback (Docker path): let SvelteKit's normal routing
+		// miss the request, which 404s. Docker users hit the API at PUBLIC_API_URL
+		// directly, so this branch never matters in practice.
+	}
+	return resolve(event);
+};

--- a/packages/web/src/lib/api-binding.ts
+++ b/packages/web/src/lib/api-binding.ts
@@ -1,0 +1,23 @@
+import type { RequestEvent } from '@sveltejs/kit';
+
+/**
+ * Returns a fetch implementation suitable for SSR data loads.
+ *
+ * Under Cloudflare Workers, `event.platform.env.API` is the service binding
+ * to the API Worker. We rewrite incoming URLs to a synthetic
+ * `https://api.internal/<path>` and dispatch through the binding so the
+ * request never leaves the Cloudflare edge.
+ *
+ * Under adapter-node (Docker path), there is no platform binding, so we
+ * fall back to SvelteKit's `event.fetch` which respects the local relative
+ * routing rules and existing `PUBLIC_API_URL` configuration.
+ */
+export function bindingFetch(event: RequestEvent): typeof fetch {
+	const api = (event.platform as any)?.env?.API;
+	if (!api) return event.fetch;
+	return async (input, init) => {
+		const url = typeof input === 'string' ? input : (input as Request).url;
+		const pathOnly = url.replace(/^https?:\/\/[^/]+/, '');
+		return api.fetch(new Request(`https://api.internal${pathOnly}`, init));
+	};
+}

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -2,7 +2,7 @@ import createClient from 'openapi-fetch';
 import type { paths } from '$lib/types/api.d';
 import { env } from '$env/dynamic/public';
 
-const BASE_URL = env.PUBLIC_API_URL || 'http://localhost:3000';
+const BASE_URL = env.PUBLIC_API_URL ?? (typeof window !== 'undefined' ? '' : 'http://localhost:3000');
 
 export function createApiClient(customFetch?: typeof fetch) {
 	return createClient<paths>({

--- a/packages/web/src/routes/inbox/[address]/+page.server.ts
+++ b/packages/web/src/routes/inbox/[address]/+page.server.ts
@@ -1,10 +1,12 @@
 import { fetchInbox } from '$lib/api';
+import { bindingFetch } from '$lib/api-binding';
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async ({ params, url, fetch }) => {
+export const load: PageServerLoad = async (event) => {
+	const { params, url } = event;
 	const page = Number(url.searchParams.get('page')) || 1;
 	const limit = Number(url.searchParams.get('limit')) || 20;
-	const data = await fetchInbox(params.address, page, limit, fetch);
+	const data = await fetchInbox(params.address, page, limit, bindingFetch(event));
 	return {
 		address: params.address,
 		...data,

--- a/packages/web/svelte.config.js
+++ b/packages/web/svelte.config.js
@@ -1,11 +1,12 @@
-import adapter from '@sveltejs/adapter-node';
+const adapterName = process.env.ADAPTER || 'node';
+const adapterModule = adapterName === 'cloudflare'
+	? await import('@sveltejs/adapter-cloudflare')
+	: await import('@sveltejs/adapter-node');
+const adapter = adapterModule.default;
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {
-		// adapter-auto only supports some environments, see https://svelte.dev/docs/kit/adapter-auto for a list.
-		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.
-		// See https://svelte.dev/docs/kit/adapters for more information about adapters.
 		adapter: adapter()
 	}
 };

--- a/packages/web/wrangler.toml.example
+++ b/packages/web/wrangler.toml.example
@@ -1,0 +1,21 @@
+# packages/web/wrangler.toml.example
+# Static fallback for the Cloudflare Deploy Button. Copy to wrangler.toml,
+# adjust the worker / service names, then run `wrangler deploy`.
+# The recommended path is `bunx cloakmail-cli setup`, which renders
+# wrangler.toml from wrangler.toml.template instead.
+name = "cloakmail-web"
+main = ".svelte-kit/cloudflare/_worker.js"
+compatibility_date = "2025-01-01"
+compatibility_flags = ["nodejs_compat"]
+
+[assets]
+directory = ".svelte-kit/cloudflare"
+binding = "ASSETS"
+
+[vars]
+PUBLIC_APP_NAME = "CloakMail"
+PUBLIC_EMAIL_DOMAIN = "example.com"
+
+[[services]]
+binding = "API"
+service = "cloakmail-api"

--- a/packages/web/wrangler.toml.template
+++ b/packages/web/wrangler.toml.template
@@ -1,0 +1,20 @@
+# packages/web/wrangler.toml.template
+# Rendered to wrangler.toml by cloakmail-cli setup. Do not edit the rendered file.
+name = "{{WEB_WORKER_NAME}}"
+main = ".svelte-kit/cloudflare/_worker.js"
+compatibility_date = "2025-01-01"
+compatibility_flags = ["nodejs_compat"]
+
+[assets]
+directory = ".svelte-kit/cloudflare"
+binding = "ASSETS"
+
+[vars]
+PUBLIC_APP_NAME = "{{APP_NAME}}"
+PUBLIC_EMAIL_DOMAIN = "{{DOMAIN}}"
+# PUBLIC_API_URL omitted on purpose: client-side fetches use same-origin /api/*
+# which the hooks.server.ts proxy forwards to the API Worker via service binding.
+
+[[services]]
+binding = "API"
+service = "{{API_WORKER_NAME}}"


### PR DESCRIPTION
## Release v1.1.0

Adds a second deployment path for CloakMail running entirely on the **Cloudflare free tier** (Workers + D1 + R2 + Email Routing), plus a small Docker ergonomics fix. No breaking changes.

## What's new

### Cloudflare deployment path
- New `packages/cloudflare` workspace: Hono API + `email()` handler + `scheduled()` TTL sweep, running on Cloudflare Workers
- **D1 + R2 smart split** storage — small emails inline in D1 (1 write), large emails spilled to R2. Free-tier ceiling ~100k emails/day
- **Single-hostname architecture** — the web worker proxies `/api/*` to the API worker via a service binding, so the API has zero public surface area and users pick any hostname they want
- `packages/web/svelte.config.js` now picks `adapter-cloudflare` when `ADAPTER=cloudflare` is set, otherwise defaults to `adapter-node` (Docker build unchanged)
- `wrangler.toml.template` files rendered by the [`cloakmail-cli`](https://github.com/DreamsHive/cloakmail-cli) wizard at deploy time

### One-command install
End-to-end deployment is owned by a separate CLI:

```bash
bunx cloakmail-cli setup
```

It fetches this release's tarball, prompts for your Cloudflare token + zone + hostname, provisions D1 and R2, renders both `wrangler.toml` files, deploys the workers, applies migrations, enables Email Routing, binds the custom domain, and verifies the full path — in about two minutes. See the CLI repo for details.

### Docker improvements
- **Overridable `PUBLIC_API_URL`** in `docker-compose.yml` ([bb6368d](https://github.com/DreamsHive/cloakmail/commit/bb6368deeadb7711e039a656e926826a3e64449e), thanks @rstefko!) — the web container now reads `PUBLIC_API_URL=${API_URL:-http://server:3000}`, so you can point the web UI at an API on a different host (reverse proxy, split deployment, remote dev) without editing the compose file. The default is unchanged, so existing `docker compose up` setups keep working as-is.

  ```bash
  # New: override the API URL from your environment or .env
  API_URL=https://api.example.com docker compose up -d
  ```

### Community files
- `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1)
- `CONTRIBUTING.md` with per-package dev workflow
- PR template and structured bug / feature issue forms

### Release infra
- `.github/workflows/publish.yml` — triggers on `v*` tags, re-runs the full test suite, publishes non-private workspace packages with `--provenance`, creates a GitHub Release
- `.github/workflows/cloudflare-deploy.yml` — optional CI deploy on push for users who want automation

## What's unchanged

- `packages/server` (Bun + Elysia + smtp-server + Redis) — no code changes
- `docker-compose.production.yml`
- `.github/workflows/{ci.yml,docker-publish.yml}`
- GHCR images (same names, same tags)
- Environment variable contract — `API_URL` is new but **optional** with a backward-compatible default

## Upgrade

**Docker users** — zero-config upgrade:

```bash
docker compose pull && docker compose up -d
```

If you want to point the web UI at an API on a different host, add `API_URL=https://api.example.com` to your `.env` and restart.

**Fresh Cloudflare deployment:**

```bash
bunx cloakmail-cli setup
```

## Contributors

Thanks to @rstefko for the `PUBLIC_API_URL` override fix!

## Full changelog

See the auto-generated release notes on the GitHub Release once this PR lands and the `v1.1.0` tag is pushed.